### PR TITLE
Generate requirements file with pipreqs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+astropy
+Flask
+google_auth_oauthlib
+gspread
+matplotlib
+numpy
+pandas
+poliastro
+protobuf
+python-dotenv
+reportlab
+scipy
+sgp4
+skyfield
+yagmail


### PR DESCRIPTION
## Summary
- create requirements.txt using pipreqs with no pinned versions

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686ac1789bcc8328bad7440394d0a935