### PR TITLE
Add rideshare mission mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,6 +45,8 @@ DEFAULT_HASHRATE_PER_ASIC = 0.63  # TH/s
 # Default efficiency is ~19 J/TH which implies about 12 W per ASIC
 DEFAULT_EFFICIENCY_J_PER_TH = 19.0
 DEFAULT_POWER_PER_ASIC = DEFAULT_EFFICIENCY_J_PER_TH * DEFAULT_HASHRATE_PER_ASIC
+DEFAULT_SOLAR_POWER_W = 1000.0
+DEFAULT_SOLAR_COST_PER_W = 1000.0
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
 orbits_path = os.path.join(ROOT, "config", "orbits_to_test.json")
@@ -181,6 +183,8 @@ def index():
         btc_hash_grows=BITCOIN_HASH_GROWTH_OPTIONS,
         networks=NETWORK_OPTIONS,
         default_efficiency=round(DEFAULT_EFFICIENCY_J_PER_TH, 1),
+        default_solar_power=DEFAULT_SOLAR_POWER_W,
+        default_solar_cost=DEFAULT_SOLAR_COST_PER_W,
     )
 
 
@@ -247,6 +251,19 @@ def api_estimate_cost():
 
         efficiency = float(data.get("efficiency", DEFAULT_EFFICIENCY_J_PER_TH))
         power_per_asic = efficiency * DEFAULT_HASHRATE_PER_ASIC
+
+        mode = data.get("mode", "dedicated")
+        if mode == "rideshare":
+            solar_power = float(data.get("solar_power", DEFAULT_SOLAR_POWER_W))
+            solar_cost = float(data.get("solar_cost", DEFAULT_SOLAR_COST_PER_W))
+            asic_count = int(solar_power / power_per_asic) if power_per_asic else 0
+            total_cost = solar_power * solar_cost
+            breakdown = {
+                "Solar Panel Cost": total_cost,
+                "Cost per W": solar_cost,
+                "ASIC Count": asic_count,
+            }
+            return jsonify({"total_cost": total_cost, "breakdown": breakdown})
 
         sat_class = data.get("sat_class", "cubesat")
         if sat_class == "multimw":
@@ -409,30 +426,68 @@ def api_simulate():
         btc_hash = float(data.get("btc_hash_growth", 25)) / 100.0
 
         mission_life = float(data.get("mission_life", 5))
-        capex = {
-            **costs,
-            "launch_cost": launch_cost,
-            "asic_count": params["asic_count"],
-            "hashrate_per_asic": DEFAULT_HASHRATE_PER_ASIC,
-            "power_per_asic": power_per_asic,
-            "btc_price_growth": btc_app,
-            "network_hashrate_growth": btc_hash,
-            "mission_lifetime": mission_life,
-        }
-        cost_data = run_cost_model(env.sunlight_fraction, **capex)
-        cost_data["launch_cost_per_kg"] = cost_per_kg
+        mode = data.get("mode", "dedicated")
+        if mode == "rideshare":
+            solar_power = float(data.get("solar_power", DEFAULT_SOLAR_POWER_W))
+            solar_cost = float(data.get("solar_cost", DEFAULT_SOLAR_COST_PER_W))
+            asic_power_pct = float(data.get("asic_power_pct", 100))
+            asic_count = int(solar_power / power_per_asic) if power_per_asic else 0
+            effective_fraction = env.sunlight_fraction * (asic_power_pct / 100.0)
+            capex = {
+                "bus_cost": 0,
+                "payload_cost": solar_power * solar_cost,
+                "launch_cost": 0,
+                "overhead": 0,
+                "integration_cost": 0,
+                "comms_cost": 0,
+                "contingency": 0,
+                "asic_count": asic_count,
+                "hashrate_per_asic": DEFAULT_HASHRATE_PER_ASIC,
+                "power_per_asic": power_per_asic,
+                "btc_price_growth": btc_app,
+                "network_hashrate_growth": btc_hash,
+                "mission_lifetime": mission_life,
+            }
+            cost_data = run_cost_model(effective_fraction, **capex)
+            cost_data["launch_cost_per_kg"] = 0
+        else:
+            capex = {
+                **costs,
+                "launch_cost": launch_cost,
+                "asic_count": params["asic_count"],
+                "hashrate_per_asic": DEFAULT_HASHRATE_PER_ASIC,
+                "power_per_asic": power_per_asic,
+                "btc_price_growth": btc_app,
+                "network_hashrate_growth": btc_hash,
+                "mission_lifetime": mission_life,
+            }
+            cost_data = run_cost_model(env.sunlight_fraction, **capex)
+            cost_data["launch_cost_per_kg"] = cost_per_kg
 
-        revenue_curve = project_revenue_curve(
-            env.sunlight_fraction,
-            mission_life,
-            params["asic_count"],
-            hashrate_per_asic=capex.get("hashrate_per_asic", DEFAULT_HASHRATE_PER_ASIC),
-            btc_price=capex.get("btc_price", 105000.0),
-            btc_price_growth=btc_app,
-            network_hashrate_ehs=capex.get("network_hashrate_ehs", 700.0),
-            network_hashrate_growth=btc_hash,
-            block_reward_btc=capex.get("block_reward_btc", 3.125),
-        )
+        if mode == "rideshare":
+            revenue_curve = project_revenue_curve(
+                effective_fraction,
+                mission_life,
+                asic_count,
+                hashrate_per_asic=DEFAULT_HASHRATE_PER_ASIC,
+                btc_price=capex.get("btc_price", 105000.0),
+                btc_price_growth=btc_app,
+                network_hashrate_ehs=capex.get("network_hashrate_ehs", 700.0),
+                network_hashrate_growth=btc_hash,
+                block_reward_btc=capex.get("block_reward_btc", 3.125),
+            )
+        else:
+            revenue_curve = project_revenue_curve(
+                env.sunlight_fraction,
+                mission_life,
+                params["asic_count"],
+                hashrate_per_asic=capex.get("hashrate_per_asic", DEFAULT_HASHRATE_PER_ASIC),
+                btc_price=capex.get("btc_price", 105000.0),
+                btc_price_growth=btc_app,
+                network_hashrate_ehs=capex.get("network_hashrate_ehs", 700.0),
+                network_hashrate_growth=btc_hash,
+                block_reward_btc=capex.get("block_reward_btc", 3.125),
+            )
         roi_buf = roi_plot_to_buffer(cost_data["total_cost"], revenue_curve, step=0.25)
 
         rad_model = RadiationModel()
@@ -442,28 +497,35 @@ def api_simulate():
             years=cost_data["mission_lifetime"],
         )
 
-        power_model = PowerModel(
-            power_density_w_m2=(
-                params["power_w"] / params["solar_area_m2"]
-                if params.get("solar_area_m2")
-                else 200
+        if mode == "rideshare":
+            available_power = solar_power
+            specs = {
+                "asic_count": asic_count,
+                "solar_power_w": solar_power,
+                "asic_efficiency_j_per_th": efficiency,
+                "asic_power_pct": asic_power_pct,
+            }
+        else:
+            power_model = PowerModel(
+                power_density_w_m2=(
+                    params["power_w"] / params["solar_area_m2"]
+                    if params.get("solar_area_m2")
+                    else 200
+                )
             )
-        )
-        # Report the rated power for the chosen satellite class so it aligns
-        # with the cost model's power value, avoiding inconsistent outputs.
-        available_power = params["power_w"]
+            available_power = params["power_w"]
 
-        specs = {
-            "asic_count": params["asic_count"],
-            "solar_area_m2": params["solar_area_m2"],
-            "power_w": params["power_w"],
-            "asic_efficiency_j_per_th": efficiency,
-            "solar_power_density_w_m2": (
-                params["power_w"] / params["solar_area_m2"]
-                if params["solar_area_m2"]
-                else None
-            ),
-        }
+            specs = {
+                "asic_count": params["asic_count"],
+                "solar_area_m2": params["solar_area_m2"],
+                "power_w": params["power_w"],
+                "asic_efficiency_j_per_th": efficiency,
+                "solar_power_density_w_m2": (
+                    params["power_w"] / params["solar_area_m2"]
+                    if params["solar_area_m2"]
+                    else None
+                ),
+            }
 
         result = {
             "orbit": orbit_cfg.get("name"),

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,6 +30,12 @@
             {% endfor %}
         </select>
         <br><br>
+        <label for="mode">Mission Type:</label>
+        <select id="mode" name="mode" onchange="updateMode()">
+            <option value="dedicated">Dedicated Bitcoin Miner</option>
+            <option value="rideshare">Rideshare Panels</option>
+        </select>
+        <br><br>
         <label for="sat_class">Select Satellite Class:</label>
         <select id="sat_class" name="sat_class" onchange="updateSatClass()">
             {% for value, label in sat_classes %}
@@ -45,6 +51,14 @@
         <span class="slider-label">ASIC Efficiency (J/TH, default {{ default_efficiency }}): <span id="efficiency_val">{{ default_efficiency }}</span></span>
         <input type="range" id="efficiency" name="efficiency" min="14" max="{{ default_efficiency + 5 }}" value="{{ default_efficiency }}" step="0.1" oninput="document.getElementById('efficiency_val').innerText=this.value; updateCost();">
         <br>
+        <div id="rideshare_opts" style="display:none; margin-bottom:10px;">
+            <span class="slider-label">Solar Panel Power (W): <span id="solar_power_val">{{ default_solar_power }}</span></span>
+            <input type="range" id="solar_power" name="solar_power" min="100" max="10000" value="{{ default_solar_power }}" step="100" oninput="document.getElementById('solar_power_val').innerText=this.value; updateCost();">
+            <span class="slider-label">Solar Cost ($/W): <span id="solar_cost_val">{{ default_solar_cost }}</span></span>
+            <input type="range" id="solar_cost" name="solar_cost" min="50" max="2000" value="{{ default_solar_cost }}" step="50" oninput="document.getElementById('solar_cost_val').innerText=this.value; updateCost();">
+            <span class="slider-label">ASIC Power Allocation (%): <span id="asic_power_pct_val">100</span>%</span>
+            <input type="range" id="asic_power_pct" name="asic_power_pct" min="0" max="100" value="100" step="5" oninput="document.getElementById('asic_power_pct_val').innerText=this.value;">
+        </div>
         <label for="comms_mode">Comms Uptime:</label>
         <select id="comms_mode" name="comms_mode" onchange="updateCommsMode()">
             <option value="ground">Ground Stations</option>
@@ -154,6 +168,14 @@
             updateCost();
         }
 
+        function updateMode() {
+            const m = document.getElementById('mode').value;
+            const r = document.getElementById('rideshare_opts');
+            r.style.display = m === 'rideshare' ? 'block' : 'none';
+            clearVisuals();
+            updateCost();
+        }
+
         function updateSatClass() {
             const cls = document.getElementById('sat_class').value;
             const opts = document.getElementById('multimw_opts');
@@ -178,9 +200,15 @@
                 launch: document.getElementById('launch').value,
                 sat_class: document.getElementById('sat_class').value,
                 efficiency: document.getElementById('efficiency').value,
+                mode: document.getElementById('mode').value
             };
             if (data.sat_class === 'multimw') {
                 data.multimw_power = document.getElementById('multimw_power').value;
+            }
+            if (data.mode === 'rideshare') {
+                data.solar_power = document.getElementById('solar_power').value;
+                data.solar_cost = document.getElementById('solar_cost').value;
+                data.asic_power_pct = document.getElementById('asic_power_pct').value;
             }
             return data;
         }
@@ -225,6 +253,7 @@
                 launch: document.getElementById('launch').value,
                 sat_class: document.getElementById('sat_class').value,
                 efficiency: document.getElementById('efficiency').value,
+                mode: document.getElementById('mode').value,
                 comms_mode: document.getElementById('comms_mode').value,
                 gs_network: document.getElementById('gs_network').value,
                 btc_appreciation: document.getElementById('btc_appreciation').value,
@@ -233,6 +262,11 @@
             };
             if (data.sat_class === 'multimw') {
                 data.multimw_power = document.getElementById('multimw_power').value;
+            }
+            if (data.mode === 'rideshare') {
+                data.solar_power = document.getElementById('solar_power').value;
+                data.solar_cost = document.getElementById('solar_cost').value;
+                data.asic_power_pct = document.getElementById('asic_power_pct').value;
             }
             fetch('/api/simulate', {
                 method: 'POST',
@@ -276,6 +310,7 @@
             });
         }
         window.onload = function() {
+            updateMode();
             updateCommsMode();
             updateSatClass();
             clearVisuals();


### PR DESCRIPTION
## Summary
- add dropdown to select dedicated or rideshare mission mode
- support rideshare-specific solar panel options and ASIC power allocation
- update cost estimation and simulation endpoints with rideshare logic

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686dba5c1b0c8328aa76a4c45e102a1d