### PR TITLE
Add power slider customization

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,6 +45,10 @@ DEFAULT_HASHRATE_PER_ASIC = 0.63  # TH/s
 # Default efficiency is ~19 J/TH which implies about 12 W per ASIC
 DEFAULT_EFFICIENCY_J_PER_TH = 19.0
 DEFAULT_POWER_PER_ASIC = DEFAULT_EFFICIENCY_J_PER_TH * DEFAULT_HASHRATE_PER_ASIC
+DEFAULT_SOLAR_POWER_W = 1000.0
+# Default rideshare solar panel price per Watt ($/W). Range may vary widely,
+# but typical commercial rates are well below $100/W.
+DEFAULT_SOLAR_COST_PER_W = 10.0
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
 orbits_path = os.path.join(ROOT, "config", "orbits_to_test.json")
@@ -181,6 +185,8 @@ def index():
         btc_hash_grows=BITCOIN_HASH_GROWTH_OPTIONS,
         networks=NETWORK_OPTIONS,
         default_efficiency=round(DEFAULT_EFFICIENCY_J_PER_TH, 1),
+        default_solar_power=DEFAULT_SOLAR_POWER_W,
+        default_solar_cost=DEFAULT_SOLAR_COST_PER_W,
     )
 
 
@@ -248,6 +254,19 @@ def api_estimate_cost():
         efficiency = float(data.get("efficiency", DEFAULT_EFFICIENCY_J_PER_TH))
         power_per_asic = efficiency * DEFAULT_HASHRATE_PER_ASIC
 
+        mode = data.get("mode", "dedicated")
+        if mode == "rideshare":
+            solar_power = float(data.get("solar_power", DEFAULT_SOLAR_POWER_W))
+            solar_cost = float(data.get("solar_cost", DEFAULT_SOLAR_COST_PER_W))
+            asic_count = int(solar_power / power_per_asic) if power_per_asic else 0
+            total_cost = solar_power * solar_cost
+            breakdown = {
+                "Solar Panel Cost": total_cost,
+                "Cost per W": solar_cost,
+                "ASIC Count": asic_count,
+            }
+            return jsonify({"total_cost": total_cost, "breakdown": breakdown})
+
         sat_class = data.get("sat_class", "cubesat")
         if sat_class == "multimw":
             power_mw = float(data.get("multimw_power", 1))
@@ -277,10 +296,15 @@ def api_estimate_cost():
             launch_cost = best["total_cost_usd"]
             cost_per_kg = best.get("cost_per_kg_usd", 0)
 
+        ded_power = float(data.get("ded_power", 0))
+        asic_override = None
+        if ded_power > 0 and sat_class in ("cubesat", "espa"):
+            asic_override = int(ded_power / power_per_asic) if power_per_asic else 0
+
         capex = {
             **costs,
             "launch_cost": launch_cost,
-            "asic_count": params["asic_count"],
+            "asic_count": asic_override if asic_override is not None else params["asic_count"],
             "hashrate_per_asic": DEFAULT_HASHRATE_PER_ASIC,
             "power_per_asic": power_per_asic,
         }
@@ -409,30 +433,73 @@ def api_simulate():
         btc_hash = float(data.get("btc_hash_growth", 25)) / 100.0
 
         mission_life = float(data.get("mission_life", 5))
-        capex = {
-            **costs,
-            "launch_cost": launch_cost,
-            "asic_count": params["asic_count"],
-            "hashrate_per_asic": DEFAULT_HASHRATE_PER_ASIC,
-            "power_per_asic": power_per_asic,
-            "btc_price_growth": btc_app,
-            "network_hashrate_growth": btc_hash,
-            "mission_lifetime": mission_life,
-        }
-        cost_data = run_cost_model(env.sunlight_fraction, **capex)
-        cost_data["launch_cost_per_kg"] = cost_per_kg
+        mode = data.get("mode", "dedicated")
+        if mode == "rideshare":
+            solar_power = float(data.get("solar_power", DEFAULT_SOLAR_POWER_W))
+            solar_cost = float(data.get("solar_cost", DEFAULT_SOLAR_COST_PER_W))
+            asic_power_pct = float(data.get("asic_power_pct", 100))
+            asic_count = int(solar_power / power_per_asic) if power_per_asic else 0
+            effective_fraction = env.sunlight_fraction * (asic_power_pct / 100.0)
+            capex = {
+                "bus_cost": 0,
+                "payload_cost": solar_power * solar_cost,
+                "launch_cost": 0,
+                "overhead": 0,
+                "integration_cost": 0,
+                "comms_cost": 0,
+                "contingency": 0,
+                "asic_count": asic_count,
+                "hashrate_per_asic": DEFAULT_HASHRATE_PER_ASIC,
+                "power_per_asic": power_per_asic,
+                "btc_price_growth": btc_app,
+                "network_hashrate_growth": btc_hash,
+                "mission_lifetime": mission_life,
+            }
+            cost_data = run_cost_model(effective_fraction, **capex)
+            cost_data["launch_cost_per_kg"] = 0
+        else:
+            ded_power = float(data.get("ded_power", 0))
+            asic_override = None
+            if ded_power > 0 and sat_class in ("cubesat", "espa"):
+                asic_override = int(ded_power / power_per_asic) if power_per_asic else 0
 
-        revenue_curve = project_revenue_curve(
-            env.sunlight_fraction,
-            mission_life,
-            params["asic_count"],
-            hashrate_per_asic=capex.get("hashrate_per_asic", DEFAULT_HASHRATE_PER_ASIC),
-            btc_price=capex.get("btc_price", 105000.0),
-            btc_price_growth=btc_app,
-            network_hashrate_ehs=capex.get("network_hashrate_ehs", 700.0),
-            network_hashrate_growth=btc_hash,
-            block_reward_btc=capex.get("block_reward_btc", 3.125),
-        )
+            capex = {
+                **costs,
+                "launch_cost": launch_cost,
+                "asic_count": asic_override if asic_override is not None else params["asic_count"],
+                "hashrate_per_asic": DEFAULT_HASHRATE_PER_ASIC,
+                "power_per_asic": power_per_asic,
+                "btc_price_growth": btc_app,
+                "network_hashrate_growth": btc_hash,
+                "mission_lifetime": mission_life,
+            }
+            cost_data = run_cost_model(env.sunlight_fraction, **capex)
+            cost_data["launch_cost_per_kg"] = cost_per_kg
+
+        if mode == "rideshare":
+            revenue_curve = project_revenue_curve(
+                effective_fraction,
+                mission_life,
+                asic_count,
+                hashrate_per_asic=DEFAULT_HASHRATE_PER_ASIC,
+                btc_price=capex.get("btc_price", 105000.0),
+                btc_price_growth=btc_app,
+                network_hashrate_ehs=capex.get("network_hashrate_ehs", 700.0),
+                network_hashrate_growth=btc_hash,
+                block_reward_btc=capex.get("block_reward_btc", 3.125),
+            )
+        else:
+            revenue_curve = project_revenue_curve(
+                env.sunlight_fraction,
+                mission_life,
+                (asic_override if asic_override is not None else params["asic_count"]),
+                hashrate_per_asic=capex.get("hashrate_per_asic", DEFAULT_HASHRATE_PER_ASIC),
+                btc_price=capex.get("btc_price", 105000.0),
+                btc_price_growth=btc_app,
+                network_hashrate_ehs=capex.get("network_hashrate_ehs", 700.0),
+                network_hashrate_growth=btc_hash,
+                block_reward_btc=capex.get("block_reward_btc", 3.125),
+            )
         roi_buf = roi_plot_to_buffer(cost_data["total_cost"], revenue_curve, step=0.25)
 
         rad_model = RadiationModel()
@@ -442,28 +509,35 @@ def api_simulate():
             years=cost_data["mission_lifetime"],
         )
 
-        power_model = PowerModel(
-            power_density_w_m2=(
-                params["power_w"] / params["solar_area_m2"]
-                if params.get("solar_area_m2")
-                else 200
+        if mode == "rideshare":
+            available_power = solar_power
+            specs = {
+                "asic_count": asic_count,
+                "solar_power_w": solar_power,
+                "asic_efficiency_j_per_th": efficiency,
+                "asic_power_pct": asic_power_pct,
+            }
+        else:
+            power_model = PowerModel(
+                power_density_w_m2=(
+                    params["power_w"] / params["solar_area_m2"]
+                    if params.get("solar_area_m2")
+                    else 200
+                )
             )
-        )
-        # Report the rated power for the chosen satellite class so it aligns
-        # with the cost model's power value, avoiding inconsistent outputs.
-        available_power = params["power_w"]
+            available_power = ded_power if ded_power > 0 else params["power_w"]
 
-        specs = {
-            "asic_count": params["asic_count"],
-            "solar_area_m2": params["solar_area_m2"],
-            "power_w": params["power_w"],
-            "asic_efficiency_j_per_th": efficiency,
-            "solar_power_density_w_m2": (
-                params["power_w"] / params["solar_area_m2"]
-                if params["solar_area_m2"]
-                else None
-            ),
-        }
+            specs = {
+                "asic_count": asic_override if asic_override is not None else params["asic_count"],
+                "solar_area_m2": params["solar_area_m2"],
+                "power_w": available_power,
+                "asic_efficiency_j_per_th": efficiency,
+                "solar_power_density_w_m2": (
+                    available_power / params["solar_area_m2"]
+                    if params["solar_area_m2"]
+                    else None
+                ),
+            }
 
         result = {
             "orbit": orbit_cfg.get("name"),

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,6 +30,12 @@
             {% endfor %}
         </select>
         <br><br>
+        <label for="mode">Mission Type:</label>
+        <select id="mode" name="mode" onchange="updateMode()">
+            <option value="dedicated">Dedicated Bitcoin Miner</option>
+            <option value="rideshare">Rideshare Panels</option>
+        </select>
+        <br><br>
         <label for="sat_class">Select Satellite Class:</label>
         <select id="sat_class" name="sat_class" onchange="updateSatClass()">
             {% for value, label in sat_classes %}
@@ -41,10 +47,22 @@
             <input type="range" id="multimw_power" name="multimw_power" min="1" max="60" value="1" step="1" oninput="document.getElementById('multimw_power_val').innerText=this.value; updateCost();">
             <div style="font-size:smaller;">60&nbsp;MW nears the theoretical perfect compaction of a 0.005&nbsp;m panel inside Starship's payload volume, assuming roughly 275&nbsp;W/m<sup>2</sup> power density.</div>
         </div>
+        <div id="ded_power_opts" style="display:none; margin-top:8px;">
+            <span class="slider-label">Total Power (W): <span id="ded_power_val">1000</span></span>
+            <input type="range" id="ded_power" name="ded_power" min="40" max="30000" value="1000" step="10" oninput="document.getElementById('ded_power_val').innerText=this.value; updateCost();">
+        </div>
         <br>
         <span class="slider-label">ASIC Efficiency (J/TH, default {{ default_efficiency }}): <span id="efficiency_val">{{ default_efficiency }}</span></span>
         <input type="range" id="efficiency" name="efficiency" min="14" max="{{ default_efficiency + 5 }}" value="{{ default_efficiency }}" step="0.1" oninput="document.getElementById('efficiency_val').innerText=this.value; updateCost();">
         <br>
+        <div id="rideshare_opts" style="display:none; margin-bottom:10px;">
+            <span class="slider-label">Solar Panel Power (W): <span id="solar_power_val">{{ default_solar_power }}</span></span>
+            <input type="range" id="solar_power" name="solar_power" min="40" max="30000" value="{{ default_solar_power }}" step="10" oninput="document.getElementById('solar_power_val').innerText=this.value; updateCost();">
+            <span class="slider-label">Solar Cost ($/W): <span id="solar_cost_val">{{ default_solar_cost }}</span></span>
+            <input type="range" id="solar_cost" name="solar_cost" min="0.0005" max="75" value="{{ default_solar_cost }}" step="0.01" oninput="document.getElementById('solar_cost_val').innerText=this.value; updateCost();">
+            <span class="slider-label">ASIC Power Allocation (%): <span id="asic_power_pct_val">100</span>%</span>
+            <input type="range" id="asic_power_pct" name="asic_power_pct" min="0" max="100" value="100" step="5" oninput="document.getElementById('asic_power_pct_val').innerText=this.value;">
+        </div>
         <label for="comms_mode">Comms Uptime:</label>
         <select id="comms_mode" name="comms_mode" onchange="updateCommsMode()">
             <option value="ground">Ground Stations</option>
@@ -154,10 +172,37 @@
             updateCost();
         }
 
+        function updateMode() {
+            const m = document.getElementById('mode').value;
+            const r = document.getElementById('rideshare_opts');
+            r.style.display = m === 'rideshare' ? 'block' : 'none';
+            const d = document.getElementById('ded_power_opts');
+            if (m === 'dedicated') {
+                const cls = document.getElementById('sat_class').value;
+                d.style.display = (cls === 'cubesat' || cls === 'espa') ? 'block' : 'none';
+            } else {
+                d.style.display = 'none';
+            }
+            clearVisuals();
+            updateCost();
+        }
+
         function updateSatClass() {
             const cls = document.getElementById('sat_class').value;
             const opts = document.getElementById('multimw_opts');
             opts.style.display = cls === 'multimw' ? 'block' : 'none';
+            const d = document.getElementById('ded_power_opts');
+            const mode = document.getElementById('mode').value;
+            if (mode === 'dedicated' && (cls === 'cubesat' || cls === 'espa')) {
+                d.style.display = 'block';
+                let def = 1000;
+                if (cls === 'cubesat') def = 40;
+                if (cls === 'espa') def = 2200;
+                document.getElementById('ded_power').value = def;
+                document.getElementById('ded_power_val').innerText = def;
+            } else {
+                d.style.display = 'none';
+            }
             updateCost();
         }
 
@@ -178,9 +223,17 @@
                 launch: document.getElementById('launch').value,
                 sat_class: document.getElementById('sat_class').value,
                 efficiency: document.getElementById('efficiency').value,
+                mode: document.getElementById('mode').value
             };
             if (data.sat_class === 'multimw') {
                 data.multimw_power = document.getElementById('multimw_power').value;
+            }
+            if (data.mode === 'rideshare') {
+                data.solar_power = document.getElementById('solar_power').value;
+                data.solar_cost = document.getElementById('solar_cost').value;
+                data.asic_power_pct = document.getElementById('asic_power_pct').value;
+            } else if (data.mode === 'dedicated' && (data.sat_class === 'cubesat' || data.sat_class === 'espa')) {
+                data.ded_power = document.getElementById('ded_power').value;
             }
             return data;
         }
@@ -225,6 +278,7 @@
                 launch: document.getElementById('launch').value,
                 sat_class: document.getElementById('sat_class').value,
                 efficiency: document.getElementById('efficiency').value,
+                mode: document.getElementById('mode').value,
                 comms_mode: document.getElementById('comms_mode').value,
                 gs_network: document.getElementById('gs_network').value,
                 btc_appreciation: document.getElementById('btc_appreciation').value,
@@ -233,6 +287,13 @@
             };
             if (data.sat_class === 'multimw') {
                 data.multimw_power = document.getElementById('multimw_power').value;
+            }
+            if (data.mode === 'rideshare') {
+                data.solar_power = document.getElementById('solar_power').value;
+                data.solar_cost = document.getElementById('solar_cost').value;
+                data.asic_power_pct = document.getElementById('asic_power_pct').value;
+            } else if (data.mode === 'dedicated' && (data.sat_class === 'cubesat' || data.sat_class === 'espa')) {
+                data.ded_power = document.getElementById('ded_power').value;
             }
             fetch('/api/simulate', {
                 method: 'POST',
@@ -276,6 +337,7 @@
             });
         }
         window.onload = function() {
+            updateMode();
             updateCommsMode();
             updateSatClass();
             clearVisuals();


### PR DESCRIPTION
## Summary
- widen rideshare solar cost slider down to 0.05c/W
- allow power slider up to 30 kW and expose optional power override for dedicated CubeSat/ESPA
- send dedicated power to the backend and compute ASIC count accordingly

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686dba5c1b0c8328aa76a4c45e102a1d