### PR TITLE
Add graph output for BTC accumulation

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@
 
 from flask import Flask, render_template, request, jsonify, send_file
 import matplotlib
+import logging
 
 matplotlib.use("Agg")
 
@@ -12,7 +13,12 @@ import os
 import pandas as pd
 from astropy import units as u
 from analysis.orbit_plot import plot_orbit_to_buffer
-from analysis.roi_plot import project_revenue_curve, roi_plot_to_buffer
+from analysis.roi_plot import (
+    project_revenue_curve,
+    roi_plot_to_buffer,
+    project_btc_curve,
+    btc_plot_to_buffer,
+)
 
 # === MAIN/UTILS (core orchestrator) ===
 
@@ -519,6 +525,17 @@ def api_simulate():
                 block_reward_btc=capex.get("block_reward_btc", 3.125),
             )
         roi_buf = roi_plot_to_buffer(cost_data["total_cost"], revenue_curve, step=0.25)
+        btc_curve = project_btc_curve(
+            env.sunlight_fraction if mode != "rideshare" else effective_fraction,
+            mission_life,
+            asic_count if mode == "rideshare" else (asic_override if asic_override is not None else params["asic_count"]),
+            step=0.25,
+            hashrate_per_asic=capex.get("hashrate_per_asic", DEFAULT_HASHRATE_PER_ASIC),
+            network_hashrate_ehs=capex.get("network_hashrate_ehs", 700.0),
+            network_hashrate_growth=btc_hash,
+            block_reward_btc=capex.get("block_reward_btc", 3.125),
+        )
+        btc_buf = btc_plot_to_buffer(btc_curve, step=0.25)
 
         rad_model = RadiationModel()
         rad_info = rad_model.estimate_tid(
@@ -575,6 +592,7 @@ def api_simulate():
                 base64.b64encode(rf_buf.getvalue()).decode("utf-8") if rf_buf else None
             ),
             "roi_plot": base64.b64encode(roi_buf.getvalue()).decode("utf-8"),
+            "btc_plot": base64.b64encode(btc_buf.getvalue()).decode("utf-8"),
         }
         return jsonify(result)
     except Exception as e:
@@ -588,5 +606,43 @@ def health():
 import os
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger(__name__)
+    # --- quick demo run of the solid state power model ---
+    try:
+        from power.solid_state_model import (
+            ModelState,
+            ModelParams,
+            simulate,
+            outputs_plot_to_buffer,
+        )
+
+        demo_params = ModelParams()
+        demo_state = ModelState(0.0, 300.0, 0.0)
+        u1 = [100.0] * 10
+        u2 = [10.0] * 10
+        u3 = [1.0] * 10
+        x1, x2, x3, y1, y2, y3 = simulate(
+            u1,
+            u2,
+            u3,
+            dt=60.0,
+            initial_state=demo_state,
+            params=demo_params,
+            return_outputs=True,
+        )
+        logger.info(
+            "Solid state model demo -> final battery %.2f Wh, temp %.2f K, BTC %.6f",
+            x1[-1],
+            x2[-1],
+            x3[-1],
+        )
+        buf = outputs_plot_to_buffer(y1, y2, y3, dt=60.0)
+        with open("solid_state_outputs.png", "wb") as f:
+            f.write(buf.getvalue())
+        logger.info("Saved demo output plot to solid_state_outputs.png")
+    except Exception as exc:  # pragma: no cover - demo should not crash server
+        logger.exception("Solid state model demo failed: %s", exc)
+
     app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 5000)))
 

--- a/power/solid_state_model.py
+++ b/power/solid_state_model.py
@@ -1,11 +1,199 @@
-# Given: initial x1, x2, x3, timestep dt, input arrays u1, u2, u3 over mission duration
-for dt:
-    P_miner = ASIC_power_max * u3
+"""Simple solid state power/thermal/bitcoin mining model."""
+
+from dataclasses import dataclass
+from typing import Iterable, Tuple
+import logging
+import io
+import numpy as np
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ModelParams:
+    """Parameters for the solid state model."""
+
+    asic_power_max: float = 50.0  # W
+    emissivity: float = 0.9
+    panel_area: float = 0.1  # m^2
+    env_temp: float = 3.0  # K
+    eff_heat_cap: float = 100.0  # J/K
+    hash_eff: float = 1e-6  # BTC/s at full power
+    max_temp: float = 350.0  # K
+
+
+@dataclass
+class ModelState:
+    battery_Wh: float
+    asic_temp_K: float
+    btc_cumulative: float
+
+
+@dataclass
+class ModelOutput:
+    """Outputs from a single model step."""
+
+    battery_Wh: float
+    btc_rate: float
+    asic_temp_K: float
+
+
+def step(state: ModelState, u1: float, u2: float, u3: float, dt: float, params: ModelParams) -> ModelState:
+    """Advance the model one timestep.
+
+    Parameters
+    ----------
+    state : ModelState
+        Current state of the system.
+    u1 : float
+        Solar power input in Watts.
+    u2 : float
+        Primary mission load in Watts.
+    u3 : float
+        ASIC throttle (0-1).
+    dt : float
+        Integration timestep in seconds.
+    params : ModelParams
+        Model configuration parameters.
+
+    Returns
+    -------
+    ModelState
+        Updated state after ``dt`` seconds.
+    """
+
+    sigma = 5.670374419e-8  # Stefan-Boltzmann constant
+    P_miner = params.asic_power_max * u3
     x1_dot = u1 - u2 - P_miner
-    Q_rad = epsilon * sigma * A * (x2**4 - T_space**4)
-    x2_dot = (u2 + P_miner - Q_rad) / C_th
-    x3_dot = hashrate_to_BTC * u3
-    x1 += x1_dot * dt
-    x2 += x2_dot * dt
-    x3 += x3_dot * dt
-    # Enforce constraints: x1 >= 0, x2 < max_temp, etc.
+    Q_rad = params.emissivity * sigma * params.panel_area * (state.asic_temp_K ** 4 - params.env_temp ** 4)
+    x2_dot = (u2 + P_miner - Q_rad) / params.eff_heat_cap
+    x3_dot = params.hash_eff * u3
+
+    state = ModelState(
+        battery_Wh=state.battery_Wh + x1_dot * dt / 3600.0,
+        asic_temp_K=state.asic_temp_K + x2_dot * dt,
+        btc_cumulative=state.btc_cumulative + x3_dot * dt,
+    )
+
+    if state.battery_Wh < 0:
+        state = ModelState(0.0, state.asic_temp_K, state.btc_cumulative)
+    if state.asic_temp_K > params.max_temp:
+        state = ModelState(state.battery_Wh, params.max_temp, state.btc_cumulative)
+
+    return state
+
+
+def calc_outputs(state: ModelState, u3: float, params: ModelParams) -> ModelOutput:
+    """Return observable outputs for the current state and input."""
+
+    return ModelOutput(
+        battery_Wh=state.battery_Wh,
+        btc_rate=params.hash_eff * u3,
+        asic_temp_K=state.asic_temp_K,
+    )
+
+
+def simulate(
+    u1: Iterable[float],
+    u2: Iterable[float],
+    u3: Iterable[float],
+    dt: float,
+    initial_state: ModelState,
+    params: ModelParams,
+    *,
+    return_outputs: bool = False,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray] | Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Run a full simulation over the provided input sequences.
+
+    Parameters
+    ----------
+    u1, u2, u3 : Iterable[float]
+        Input sequences for solar power, mission load and ASIC throttle.
+    dt : float
+        Timestep in seconds.
+    initial_state : ModelState
+        Starting state for the simulation.
+    params : ModelParams
+        Configuration parameters.
+    return_outputs : bool, optional
+        If ``True``, return output histories ``(y1, y2, y3)`` in addition to the
+        state histories.
+    """
+
+    u1 = np.asarray(list(u1), dtype=float)
+    u2 = np.asarray(list(u2), dtype=float)
+    u3 = np.asarray(list(u3), dtype=float)
+    n = len(u1)
+
+    logger.info("Simulating %d steps with dt=%s", n, dt)
+
+    x1_hist = np.empty(n)
+    x2_hist = np.empty(n)
+    x3_hist = np.empty(n)
+    if return_outputs:
+        y1_hist = np.empty(n)
+        y2_hist = np.empty(n)
+        y3_hist = np.empty(n)
+
+    state = initial_state
+    for i in range(n):
+        state = step(state, u1[i], u2[i], u3[i], dt, params)
+        x1_hist[i] = state.battery_Wh
+        x2_hist[i] = state.asic_temp_K
+        x3_hist[i] = state.btc_cumulative
+        logger.debug(
+            "step %d: battery=%.2f Wh, temp=%.2f K, btc=%.6f",
+            i,
+            state.battery_Wh,
+            state.asic_temp_K,
+            state.btc_cumulative,
+        )
+        if return_outputs:
+            out = calc_outputs(state, u3[i], params)
+            y1_hist[i] = out.battery_Wh
+            y2_hist[i] = out.btc_rate
+            y3_hist[i] = out.asic_temp_K
+
+    if return_outputs:
+        logger.info(
+            "Simulation done: final battery=%.2f Wh, temp=%.2f K, btc=%.6f",
+            state.battery_Wh,
+            state.asic_temp_K,
+            state.btc_cumulative,
+        )
+        return x1_hist, x2_hist, x3_hist, y1_hist, y2_hist, y3_hist
+    logger.info(
+        "Simulation done: final battery=%.2f Wh, temp=%.2f K, btc=%.6f",
+        state.battery_Wh,
+        state.asic_temp_K,
+        state.btc_cumulative,
+    )
+    return x1_hist, x2_hist, x3_hist
+
+
+def outputs_plot_to_buffer(y1: Iterable[float], y2: Iterable[float], y3: Iterable[float], dt: float) -> io.BytesIO:
+    """Return PNG buffer plotting outputs vs time."""
+
+    t_hours = np.arange(len(y1)) * dt / 3600.0
+
+    fig, axes = plt.subplots(3, 1, figsize=(6, 8), sharex=True)
+    axes[0].plot(t_hours, y1)
+    axes[0].set_ylabel("Battery (Wh)")
+    axes[1].plot(t_hours, y2)
+    axes[1].set_ylabel("BTC/s")
+    axes[2].plot(t_hours, y3)
+    axes[2].set_ylabel("ASIC Temp (K)")
+    axes[2].set_xlabel("Time (hr)")
+    for ax in axes:
+        ax.grid(True)
+    plt.tight_layout()
+
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png")
+    plt.close(fig)
+    buf.seek(0)
+    return buf

--- a/templates/index.html
+++ b/templates/index.html
@@ -110,6 +110,7 @@
         <img id="thermal_img" alt="Thermal plot" style="display:none;" />
         <img id="rf_plot_img" alt="RF Margin" style="display:none;" />
         <img id="roi_img" alt="ROI plot" style="display:none;" />
+        <img id="btc_img" alt="BTC plot" style="display:none;" />
     </div>
     <div id="textual" style="margin-top:1em;">
         <pre id="rf_summary"></pre>
@@ -239,6 +240,7 @@
             document.getElementById('thermal_img').style.display = 'none';
             document.getElementById('rf_plot_img').style.display = 'none';
             document.getElementById('roi_img').style.display = 'none';
+            document.getElementById('btc_img').style.display = 'none';
         }
 
         function updateOrbit() {
@@ -363,6 +365,10 @@
                 if (res.roi_plot) {
                     document.getElementById('roi_img').src = 'data:image/png;base64,' + res.roi_plot;
                     document.getElementById('roi_img').style.display = 'block';
+                }
+                if (res.btc_plot) {
+                    document.getElementById('btc_img').src = 'data:image/png;base64,' + res.btc_plot;
+                    document.getElementById('btc_img').style.display = 'block';
                 }
                 document.getElementById('rf_summary').innerText = formatObject(res.rf_summary);
                 document.getElementById('cost_breakdown').innerHTML = formatCostHTML(res.cost_summary, 2);


### PR DESCRIPTION
## Summary
- plot cumulative BTC mined over mission lifetime
- import plotting helpers and show BTC plot in the web interface
- hide BTC plot when clearing visuals

## Testing
- `python3 -m py_compile analysis/roi_plot.py power/solid_state_model.py app.py`
- `pip install --break-system-packages numpy matplotlib`
- `python3 - <<'EOF'
from power.solid_state_model import ModelState, ModelParams, simulate, outputs_plot_to_buffer
from analysis.roi_plot import project_btc_curve, btc_plot_to_buffer
params=ModelParams(); state=ModelState(0.0,300.0,0.0)
print(simulate([100]*5,[10]*5,[1]*5,dt=60,initial_state=state,params=params,return_outputs=True)[0][-1])
buf=btc_plot_to_buffer(project_btc_curve(1.0,1.0,10))
print('buf', len(buf.getvalue()))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6870492f86fc83288c5c37ac588b8751