### PR TITLE
Update 2-D thermal simulation stability

### DIFF
--- a/analysis/orbit_plot.py
+++ b/analysis/orbit_plot.py
@@ -4,6 +4,10 @@ import matplotlib
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from plot_utils import DEFAULT_FIGSIZE
 from astropy import units as u
 
 from orbits.eclipse import OrbitEnvironment
@@ -19,7 +23,7 @@ def plot_orbit_to_buffer(env: OrbitEnvironment, n_points: int = 200):
         positions.append(orb.r.to(u.km).value)
     positions = np.array(positions)
 
-    fig = plt.figure(figsize=(6, 6))
+    fig = plt.figure(figsize=DEFAULT_FIGSIZE)
     ax = fig.add_subplot(111, projection="3d")
     ax.plot(positions[:, 0], positions[:, 1], positions[:, 2], label="Orbit")
 

--- a/analysis/plot_radar.py
+++ b/analysis/plot_radar.py
@@ -1,6 +1,10 @@
 # analysis/plot_radar.py
 import numpy as np
 import matplotlib.pyplot as plt
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from plot_utils import DEFAULT_FIGSIZE
 from math import pi
 
 # ------------------------------------------------------------------
@@ -42,7 +46,7 @@ def plot_radar(df):
     N      = len(labels)
     angles = [n / float(N) * 2 * pi for n in range(N)] + [0]
 
-    fig, ax = plt.subplots(figsize=(8, 8), subplot_kw=dict(polar=True))
+    fig, ax = plt.subplots(figsize=DEFAULT_FIGSIZE, subplot_kw=dict(polar=True))
 
     for row, name in zip(data, orbit_names):
         values = list(row) + [row[0]]

--- a/analysis/roi_plot.py
+++ b/analysis/roi_plot.py
@@ -4,6 +4,10 @@ import matplotlib
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from plot_utils import DEFAULT_FIGSIZE
 
 
 def project_revenue_curve(
@@ -65,7 +69,7 @@ def roi_plot_to_buffer(total_cost, revenue_curve, step=0.25):
     years = np.arange(step, step * len(revenue_curve) + 0.0001, step)
     cumulative = np.cumsum(revenue_curve)
 
-    fig, ax = plt.subplots(figsize=(6, 4))
+    fig, ax = plt.subplots(figsize=DEFAULT_FIGSIZE)
     ax.plot(years, cumulative, label="Cumulative Revenue")
     ax.axhline(total_cost, color="r", linestyle="--", label="Total Cost")
     ax.set_xlabel("Years")
@@ -99,7 +103,7 @@ def btc_plot_to_buffer(btc_curve, step=0.25):
     years = np.arange(step, step * len(btc_curve) + 0.0001, step)
     cumulative = np.cumsum(btc_curve)
 
-    fig, ax = plt.subplots(figsize=(6, 4))
+    fig, ax = plt.subplots(figsize=DEFAULT_FIGSIZE)
     ax.plot(years, cumulative, label="BTC Mined")
     ax.set_xlabel("Years")
     ax.set_ylabel("BTC")

--- a/app.py
+++ b/app.py
@@ -34,6 +34,17 @@ from launch.launch_model import LaunchModel
 # === RADIATION FOLDER ===
 from radiation.tid_model import RadiationModel
 from radiation.Thermal import run_thermal_eclipse_model
+
+# 2-D thermal model is stored in a file that starts with a digit which makes it
+# awkward to import normally. We load it dynamically so we can reuse the helper
+# functions defined inside.
+import importlib.util
+
+_spec = importlib.util.spec_from_file_location(
+    "thermal2d", os.path.join(os.path.dirname(__file__), "radiation", "2dthermal.py")
+)
+_thermal2d = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_thermal2d)  # type: ignore
 from radiation.rf_model import (
     full_rf_visibility_simulation,
     ground_stations_by_network,
@@ -225,6 +236,17 @@ def orbit_visuals(idx: int):
             plot3d=True,
             verbose=False,
         )
+        # Run the 2-D thermal model for a representative snapshot
+        x2d, y2d, snaps2d, final2d, stats2d, boundaries = _thermal2d.run_simulation(
+            total_time_s=_thermal2d.DT_S
+        )
+        thermal2d_frames = _thermal2d.temperature_frames_base64(
+            x2d,
+            y2d,
+            snaps2d,
+            layer_boundaries_mm=boundaries,
+            times_s=stats2d.get("snapshot_times_s"),
+        )
         orbit_buf = plot_orbit_to_buffer(env)
         rf_buf = None
         comms_mode = request.args.get("comms", "ground")
@@ -242,6 +264,7 @@ def orbit_visuals(idx: int):
                 if thermal_buf
                 else None
             ),
+            "thermal2d_frames": thermal2d_frames,
             "rf_plot": (
                 base64.b64encode(rf_buf.getvalue()).decode("utf-8") if rf_buf else None
             ),
@@ -380,6 +403,16 @@ def api_simulate():
             dt=60,
             plot3d=True,
             verbose=False,
+        )
+        x2d, y2d, snaps2d, final2d, stats2d, boundaries = _thermal2d.run_simulation(
+            total_time_s=_thermal2d.DT_S
+        )
+        thermal2d_frames = _thermal2d.temperature_frames_base64(
+            x2d,
+            y2d,
+            snaps2d,
+            layer_boundaries_mm=boundaries,
+            times_s=stats2d.get("snapshot_times_s"),
         )
 
         comms_mode = data.get("comms_mode", "ground")
@@ -601,6 +634,7 @@ def api_simulate():
                 if thermal_buf
                 else None
             ),
+            "thermal2d_frames": thermal2d_frames,
             "rf_plot": (
                 base64.b64encode(rf_buf.getvalue()).decode("utf-8") if rf_buf else None
             ),
@@ -656,6 +690,29 @@ if __name__ == "__main__":
         logger.info("Saved demo output plot to solid_state_outputs.png")
     except Exception as exc:  # pragma: no cover - demo should not crash server
         logger.exception("Solid state model demo failed: %s", exc)
+
+    # --- quick demo run of the 2-D thermal model ---
+    try:
+        x, y, snaps, final_T, stats, boundaries = _thermal2d.run_simulation(
+            total_time_s=_thermal2d.DT_S
+        )
+        buf = _thermal2d.temperature_plot_to_buffer(
+            x,
+            y,
+            snaps,
+            layer_boundaries_mm=boundaries,
+            times_s=stats.get("snapshot_times_s"),
+        )
+        with open("2dthermal_result.png", "wb") as f:
+            f.write(buf.getvalue())
+        logger.info("Saved 2-D thermal demo plot to 2dthermal_result.png")
+        logger.info(
+            "2-D thermal demo -> max %.2f K, avg %.2f K",
+            stats["max_asic_K"],
+            stats["avg_asic_K"],
+        )
+    except Exception as exc:  # pragma: no cover - demo should not crash server
+        logger.exception("2-D thermal model demo failed: %s", exc)
 
     app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 5000)))
 

--- a/plot_utils.py
+++ b/plot_utils.py
@@ -1,0 +1,7 @@
+import matplotlib.pyplot as plt
+
+# Default figure size for all plots
+DEFAULT_FIGSIZE = (6, 4)
+
+# Apply default globally so code that doesn't specify figsize still gets it
+plt.rcParams["figure.figsize"] = DEFAULT_FIGSIZE

--- a/power/solid_state_model.py
+++ b/power/solid_state_model.py
@@ -9,6 +9,10 @@ import matplotlib
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from plot_utils import DEFAULT_FIGSIZE
 
 logger = logging.getLogger(__name__)
 
@@ -180,7 +184,7 @@ def outputs_plot_to_buffer(y1: Iterable[float], y2: Iterable[float], y3: Iterabl
 
     t_hours = np.arange(len(y1)) * dt / 3600.0
 
-    fig, axes = plt.subplots(3, 1, figsize=(6, 8), sharex=True)
+    fig, axes = plt.subplots(3, 1, figsize=DEFAULT_FIGSIZE, sharex=True)
     axes[0].plot(t_hours, y1)
     axes[0].set_ylabel("Battery (Wh)")
     axes[1].plot(t_hours, y2)

--- a/radiation/2dthermal.py
+++ b/radiation/2dthermal.py
@@ -1,0 +1,388 @@
+import io
+import base64
+import numpy as np
+import scipy.sparse as sp
+import scipy.sparse.linalg
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from plot_utils import DEFAULT_FIGSIZE
+
+# =====================================================================
+# Editable parameters
+# =====================================================================
+MATERIALS = {
+    "solar_cells": {"thickness": 0.2, "rho": 2330.0, "cp": 700.0, "k": 150.0},
+    "tim1": {"thickness": 0.2, "rho": 2200.0, "cp": 1000.0, "k": 3.0},
+    # 4-layer PCB stackup (2 oz copper pour)
+    "pcb_cu_top": {"thickness": 0.035, "rho": 8960.0, "cp": 385.0, "k": 400.0},
+    "pcb_prepreg1": {"thickness": 0.15, "rho": 1850.0, "cp": 900.0, "k": 0.3},
+    "pcb_cu_inner1": {"thickness": 0.035, "rho": 8960.0, "cp": 385.0, "k": 400.0},
+    "pcb_core": {"thickness": 0.8, "rho": 1850.0, "cp": 900.0, "k": 0.3},
+    "pcb_cu_inner2": {"thickness": 0.035, "rho": 8960.0, "cp": 385.0, "k": 400.0},
+    "pcb_prepreg2": {"thickness": 0.15, "rho": 1850.0, "cp": 900.0, "k": 0.3},
+    "pcb_cu_bottom": {"thickness": 0.035, "rho": 8960.0, "cp": 385.0, "k": 400.0},
+    "asic": {"thickness": 1.0, "rho": 2330.0, "cp": 700.0, "k": 130.0},
+    "tim2": {"thickness": 0.2, "rho": 2200.0, "cp": 1000.0, "k": 3.0},
+    "radiator": {"thickness": 2.0, "rho": 2700.0, "cp": 900.0, "k": 205.0},
+}
+ASIC_WIDTH_MM = 8.0
+ASIC_CENTERS_MM = [10.0, 40.0]
+ASIC_POWER_W = 9.0
+DOMAIN_WIDTH_MM = 50.0
+DX_MM = 1.0
+DY_MM = 0.010
+DT_S = 10.0  # default timestep [s]
+TOTAL_TIME_S = 180 * 60  # simulate at least two orbits (180 min)
+ALPHA_SOLAR = 0.9  # absorptivity of the solar-cell side
+EPS_RADIATOR = 0.9
+EPS_SOLAR = 0.85
+VIEW_FACTOR_TOP = 1.0
+AREA_FACTOR_TOP = 1.0
+T_SPACE = 3.0
+SOLAR_FLUX = 1361.0
+SIGMA = 5.670374419e-8
+INITIAL_T = 290.0
+
+# Names of the layers from top (y=0, radiator) to bottom (solar cells)
+LAYER_ORDER = [
+    "radiator",
+    "tim2",
+    "asic",
+    "pcb_cu_top",
+    "pcb_prepreg1",
+    "pcb_cu_inner1",
+    "pcb_core",
+    "pcb_cu_inner2",
+    "pcb_prepreg2",
+    "pcb_cu_bottom",
+    "tim1",
+    "solar_cells",
+]
+
+# =====================================================================
+# Helper routines
+# =====================================================================
+
+def build_material_grid():
+    layer_order = LAYER_ORDER
+    thicknesses = [MATERIALS[l]["thickness"] for l in layer_order]
+    total_thickness_mm = sum(thicknesses)
+    ny = int(np.ceil(total_thickness_mm / DY_MM)) + 1
+    nx = int(np.ceil(DOMAIN_WIDTH_MM / DX_MM)) + 1
+    y = np.linspace(0, total_thickness_mm, ny)
+    x = np.linspace(0, DOMAIN_WIDTH_MM, nx)
+    k = np.zeros((ny, nx))
+    rho = np.zeros((ny, nx))
+    cp = np.zeros((ny, nx))
+    Q = np.zeros((ny, nx))
+    boundaries = np.cumsum([0] + thicknesses)
+    for j, yy in enumerate(y):
+        for idx in range(len(layer_order)):
+            if boundaries[idx] <= yy < boundaries[idx + 1] or (
+                idx == len(layer_order) - 1 and yy == boundaries[idx + 1]
+            ):
+                layer_name = layer_order[idx]
+                props = MATERIALS[layer_name]
+                if layer_name == "asic":
+                    # Fill the ASIC layer with TIM2 by default; actual ASICs are set later
+                    props = MATERIALS["tim2"]
+                k[j, :] = props["k"]
+                rho[j, :] = props["rho"]
+                cp[j, :] = props["cp"]
+                break
+    asic_idx = layer_order.index("asic")
+    asic_y_start = boundaries[asic_idx]
+    asic_y_end = boundaries[asic_idx + 1]
+    j_start = int(asic_y_start / DY_MM)
+    j_end = int(np.ceil(asic_y_end / DY_MM))
+    volume_m3 = (
+        ASIC_WIDTH_MM / 1000.0
+        * MATERIALS["asic"]["thickness"] / 1000.0
+        * 0.001
+    )
+    q_asic = ASIC_POWER_W / volume_m3
+    asic_slices = []
+    for center in ASIC_CENTERS_MM:
+        asic_x_start = center - 0.5 * ASIC_WIDTH_MM
+        asic_x_end = center + 0.5 * ASIC_WIDTH_MM
+        i_start = int(asic_x_start / DX_MM)
+        i_end = int(np.ceil(asic_x_end / DX_MM))
+        for j in range(j_start, j_end):
+            for i in range(i_start, i_end):
+                k[j, i] = MATERIALS["asic"]["k"]
+                rho[j, i] = MATERIALS["asic"]["rho"]
+                cp[j, i] = MATERIALS["asic"]["cp"]
+                Q[j, i] = q_asic
+        asic_slices.append((slice(j_start, j_end), slice(i_start, i_end)))
+    return x, y, k, rho, cp, Q, asic_slices, boundaries
+
+
+def run_simulation(
+    view_factor=VIEW_FACTOR_TOP,
+    area_factor=AREA_FACTOR_TOP,
+    total_time_s=TOTAL_TIME_S,
+    dt_s=DT_S,
+):
+    """Run the transient 2-D thermal model."""
+
+    x, y, k, rho, cp, Q, asic_slices, boundaries = build_material_grid()
+    dx = DX_MM / 1000.0
+    dy = DY_MM / 1000.0
+    nx = len(x)
+    ny = len(y)
+
+    alpha = k / (rho * cp)
+    dt = dt_s
+
+    steps = int(total_time_s / dt)
+    record_steps = [0, steps // 4, steps // 2, steps - 1]
+    snapshot_times = [s * dt for s in record_steps]
+
+    T = np.full((ny, nx), INITIAL_T)
+    snapshots = []
+    src = Q / (rho * cp)
+
+    # Pre-build sparse matrix for Crank-Nicolson
+    N = nx * ny
+    main = np.ones(N)
+    left = np.zeros(N)
+    right = np.zeros(N)
+    up = np.zeros(N)
+    down = np.zeros(N)
+
+    def idx(j, i):
+        return j * nx + i
+
+    for j in range(ny):
+        for i in range(nx):
+            p = idx(j, i)
+            a = alpha[j, i]
+            main[p] = 1 + a * dt * (1 / dx ** 2 + 1 / dy ** 2)
+            if i > 0:
+                left[p] = -0.5 * a * dt / dx ** 2
+            if i < nx - 1:
+                right[p] = -0.5 * a * dt / dx ** 2
+            if j > 0:
+                up[p] = -0.5 * a * dt / dy ** 2
+            if j < ny - 1:
+                down[p] = -0.5 * a * dt / dy ** 2
+
+    A = sp.diags(
+        [down[nx:], left[1:], main, right[:-1], up[:-nx]],
+        offsets=[-nx, -1, 0, 1, nx],
+        shape=(N, N),
+        format="csr",
+    )
+
+    def laplacian(temp):
+        pad = np.pad(temp, ((1, 1), (1, 1)), mode="edge")
+        d2x = (pad[1:-1, 2:] - 2 * temp + pad[1:-1, :-2]) / dx ** 2
+        d2y = (pad[2:, 1:-1] - 2 * temp + pad[:-2, 1:-1]) / dy ** 2
+        return alpha * (d2x + d2y)
+
+    for n in range(steps):
+        bc = np.zeros_like(T)
+        q_top = -EPS_RADIATOR * view_factor * area_factor * SIGMA * (
+            T[0, :] ** 4 - T_SPACE ** 4
+        )
+        bc[0, :] += q_top / (rho[0, :] * cp[0, :] * dy)
+        q_bot = ALPHA_SOLAR * SOLAR_FLUX - EPS_SOLAR * SIGMA * (
+            T[-1, :] ** 4 - T_SPACE ** 4
+        )
+        bc[-1, :] += q_bot / (rho[-1, :] * cp[-1, :] * dy)
+
+        lap = laplacian(T)
+        B = T + 0.5 * dt * lap + dt * (src + bc)
+        T = sp.linalg.spsolve(A, B.ravel()).reshape(ny, nx)
+
+        if n in record_steps:
+            snapshots.append(T.copy())
+    asic_temps = np.concatenate([T[s] for s in asic_slices])
+    stats = {
+        "max_asic_K": float(np.max(asic_temps)),
+        "avg_asic_K": float(np.mean(asic_temps)),
+        "snapshot_times_s": snapshot_times,
+        "actual_dt_s": dt,
+    }
+    return x, y, snapshots, T, stats, boundaries
+
+
+def plot_temperature(x, y, temps, layer_boundaries_mm, times_s=None):
+    """Plot one or more temperature snapshots with layer boundaries."""
+
+    extent = [x[0], x[-1], y[0], y[-1]]
+    fig, axes = plt.subplots(
+        1,
+        len(temps),
+        figsize=(DEFAULT_FIGSIZE[0] * len(temps), DEFAULT_FIGSIZE[1]),
+        sharey=True,
+    )
+    if len(temps) == 1:
+        axes = [axes]
+
+    layer_mid = 0.5 * (np.array(layer_boundaries_mm[:-1]) + np.array(layer_boundaries_mm[1:]))
+    layer_labels = [l.replace("_", " ") for l in LAYER_ORDER]
+
+    if times_s is None:
+        times_s = [None] * len(temps)
+
+    for ax, data, t in zip(axes, temps, times_s):
+        im = ax.imshow(
+            data,
+            origin="lower",
+            extent=extent,
+            aspect="auto",
+            cmap="inferno",
+        )
+        fig.colorbar(im, ax=ax, shrink=0.8, label="Temperature (K)")
+        ax.set_xlabel("x (mm)")
+        ax.set_ylabel("y (mm)")
+        ax.set_yticks(layer_mid)
+        ax.set_yticklabels(layer_labels)
+
+        # Mark boundaries between layers
+        for boundary in layer_boundaries_mm:
+            ax.axhline(y=boundary, color="cyan", linestyle="--", linewidth=0.7)
+
+        if t is not None:
+            ax.text(
+                0.02,
+                0.95,
+                f"t = {t:.1f} s",
+                transform=ax.transAxes,
+                color="white",
+                fontsize=8,
+                ha="left",
+                va="top",
+                bbox={"facecolor": "black", "alpha": 0.3, "boxstyle": "round"},
+            )
+
+    fig.tight_layout()
+    return fig
+
+
+def single_temp_plot_to_buffer(
+    x,
+    y,
+    temp,
+    vmin=None,
+    vmax=None,
+    layer_boundaries_mm=None,
+    time_s=None,
+):
+    """Return a PNG buffer for one temperature snapshot."""
+    extent = [x[0], x[-1], y[0], y[-1]]
+    fig, ax = plt.subplots(figsize=DEFAULT_FIGSIZE)
+    im = ax.imshow(
+        temp,
+        origin="lower",
+        extent=extent,
+        aspect="auto",
+        cmap="inferno",
+        vmin=vmin,
+        vmax=vmax,
+    )
+    fig.colorbar(im, ax=ax, shrink=0.8, label="Temperature (K)")
+    ax.set_xlabel("x (mm)")
+    ax.set_ylabel("y (mm)")
+    if layer_boundaries_mm is not None:
+        mid = 0.5 * (np.array(layer_boundaries_mm[:-1]) + np.array(layer_boundaries_mm[1:]))
+        ax.set_yticks(mid)
+        ax.set_yticklabels([l.replace("_", " ") for l in LAYER_ORDER])
+        for boundary in layer_boundaries_mm:
+            ax.axhline(y=boundary, color="cyan", linestyle="--", linewidth=0.7)
+    if time_s is not None:
+        ax.text(
+            0.02,
+            0.95,
+            f"t = {time_s:.1f} s",
+            transform=ax.transAxes,
+            color="white",
+            fontsize=8,
+            ha="left",
+            va="top",
+            bbox={"facecolor": "black", "alpha": 0.3, "boxstyle": "round"},
+        )
+    fig.tight_layout()
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=200)
+    plt.close(fig)
+    buf.seek(0)
+    return buf
+
+
+def temperature_frames_base64(x, y, temps, layer_boundaries_mm=None, times_s=None):
+    """Return a list of base64 PNGs for each snapshot."""
+    vmin = float(np.min(temps[0]))
+    vmax = float(np.max(temps[-1]))
+    frames = []
+    if times_s is None:
+        times_s = [None] * len(temps)
+
+    for t_img, t_sec in zip(temps, times_s):
+        buf = single_temp_plot_to_buffer(
+            x,
+            y,
+            t_img,
+            vmin=vmin,
+            vmax=vmax,
+            layer_boundaries_mm=layer_boundaries_mm,
+            time_s=t_sec,
+        )
+        frames.append(base64.b64encode(buf.getvalue()).decode("utf-8"))
+    return frames
+
+
+def temperature_plot_to_buffer(x, y, temps, layer_boundaries_mm=None, times_s=None):
+    """Return a PNG buffer with the temperature plot."""
+
+    fig = plot_temperature(x, y, temps, layer_boundaries_mm, times_s)
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=200)
+    plt.close(fig)
+    buf.seek(0)
+    return buf
+
+
+def temperature_plot_base64(x, y, temps, layer_boundaries_mm=None, times_s=None):
+    """Return a base64-encoded PNG of the temperature plot."""
+
+    buf = temperature_plot_to_buffer(x, y, temps, layer_boundaries_mm, times_s)
+    return base64.b64encode(buf.getvalue()).decode("utf-8")
+
+
+if __name__ == "__main__":
+    # Short demo run with a tiny total time so execution remains quick.
+    x, y, snaps, final_T, stats, boundaries = run_simulation(
+        total_time_s=DT_S,
+        dt_s=DT_S,
+    )
+    times = stats.get("snapshot_times_s", [])
+    fig = plot_temperature(
+        x,
+        y,
+        snaps,
+        layer_boundaries_mm=boundaries,
+        times_s=times,
+    )
+    fig.savefig("2dthermal_result.png", dpi=200)
+    plt.close(fig)
+    frames = temperature_frames_base64(
+        x,
+        y,
+        snaps,
+        layer_boundaries_mm=boundaries,
+        times_s=times,
+    )
+    for i, b64 in enumerate(frames):
+        with open(f"2dthermal_frame_{i}.png", "wb") as f:
+            f.write(base64.b64decode(b64))
+    print(f"Max ASIC temp: {stats['max_asic_K']:.2f} K")
+    print(f"Avg ASIC temp: {stats['avg_asic_K']:.2f} K")
+    print(f"Timestep used: {stats['actual_dt_s']:.3e} s")

--- a/radiation/Thermal.py
+++ b/radiation/Thermal.py
@@ -3,6 +3,10 @@ import matplotlib
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from plot_utils import DEFAULT_FIGSIZE
 import io
 
 VERBOSE = True  # Set to True to enable detailed output
@@ -172,7 +176,7 @@ def run_thermal_eclipse_model(
     if plot3d:
         time_array = times / 3600.0
         X, Y = np.meshgrid(x, time_array)
-        fig = plt.figure(figsize=(8, 5))
+        fig = plt.figure(figsize=DEFAULT_FIGSIZE)
         ax = fig.add_subplot(111, projection="3d")
         surf = ax.plot_surface(
             X, Y, T_hist, cmap="viridis", linewidth=0, antialiased=True

--- a/radiation/rf_model.py
+++ b/radiation/rf_model.py
@@ -7,6 +7,10 @@ import matplotlib
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
+import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from plot_utils import DEFAULT_FIGSIZE
 
 VERBOSE = True  # Set to False for silent operation except summary
 
@@ -1170,7 +1174,7 @@ def rf_margin_plot_to_buffer(tle, networks=None, dt=60, verbose=False):
         tle, networks=networks, dt=dt, verbose=verbose
     )
     hours = np.array(times) / 3600.0
-    fig, ax = plt.subplots(figsize=(6, 4))
+    fig, ax = plt.subplots(figsize=DEFAULT_FIGSIZE)
     ax.plot(hours, margins)
     ax.set_xlabel("Time (hr)")
     ax.set_ylabel("Downlink Margin (dB)")
@@ -1199,7 +1203,7 @@ def constant_margin_plot_to_buffer(margin_dB=5.0, period_s=5400, dt=60):
     times = np.arange(0, period_s + dt, dt)
     margins = np.full_like(times, margin_dB, dtype=float)
     hours = times / 3600.0
-    fig, ax = plt.subplots(figsize=(6, 4))
+    fig, ax = plt.subplots(figsize=DEFAULT_FIGSIZE)
     ax.plot(hours, margins)
     ax.set_xlabel("Time (hr)")
     ax.set_ylabel("Downlink Margin (dB)")

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,6 +9,8 @@
         .slider-value { display: inline-block; min-width: 40px; }
         #visuals, #textual { display: flex; flex-wrap: wrap; gap: 10px; }
         #visuals img { max-width: 320px; }
+        /* 2-D thermal image same size as orbit plot */
+        #thermal2d_img { max-width: 320px; }
         #textual pre { background:#f5f5f5; padding:10px; margin:0; width:320px; }
     </style>
 </head>
@@ -108,6 +110,9 @@
     <div id="visuals" style="margin-top: 1em;">
         <img id="orbit_img" alt="Orbit plot" style="display:none;" />
         <img id="thermal_img" alt="Thermal plot" style="display:none;" />
+        <div style="flex-basis:100%; text-align:center;">
+            <img id="thermal2d_img" alt="2-D Thermal" style="display:none;" />
+        </div>
         <img id="rf_plot_img" alt="RF Margin" style="display:none;" />
         <img id="roi_img" alt="ROI plot" style="display:none;" />
         <img id="btc_img" alt="BTC plot" style="display:none;" />
@@ -119,6 +124,9 @@
         <pre id="rad_summary"></pre>
     </div>
     <script>
+        let thermal2dFrames = [];
+        let thermal2dTimer = null;
+        let thermal2dIndex = 0;
         function formatValue(v) {
             if (typeof v === 'number') return v.toLocaleString();
             if (typeof v === 'string') {
@@ -238,9 +246,20 @@
         function clearVisuals() {
             document.getElementById('orbit_img').style.display = 'none';
             document.getElementById('thermal_img').style.display = 'none';
+            document.getElementById('thermal2d_img').style.display = 'none';
+            if (thermal2dTimer) {
+                clearInterval(thermal2dTimer);
+                thermal2dTimer = null;
+            }
+            thermal2dFrames = [];
             document.getElementById('rf_plot_img').style.display = 'none';
             document.getElementById('roi_img').style.display = 'none';
             document.getElementById('btc_img').style.display = 'none';
+            thermal2dFrames = [];
+            if (thermal2dTimer) {
+                clearInterval(thermal2dTimer);
+                thermal2dTimer = null;
+            }
         }
 
         function updateOrbit() {
@@ -302,6 +321,7 @@
             document.getElementById('results').innerText = '';
             document.getElementById('orbit_img').style.display = 'none';
             document.getElementById('thermal_img').style.display = 'none';
+            document.getElementById('thermal2d_img').style.display = 'none';
             document.getElementById('rf_plot_img').style.display = 'none';
             document.getElementById('roi_img').style.display = 'none';
             document.getElementById('rf_summary').innerText = '';
@@ -357,6 +377,17 @@
                 if (res.thermal_plot) {
                     document.getElementById('thermal_img').src = 'data:image/png;base64,' + res.thermal_plot;
                     document.getElementById('thermal_img').style.display = 'block';
+                }
+                if (res.thermal2d_frames && res.thermal2d_frames.length) {
+                    thermal2dFrames = res.thermal2d_frames;
+                    thermal2dIndex = 0;
+                    document.getElementById('thermal2d_img').src = 'data:image/png;base64,' + thermal2dFrames[0];
+                    document.getElementById('thermal2d_img').style.display = 'block';
+                    if (thermal2dTimer) clearInterval(thermal2dTimer);
+                    thermal2dTimer = setInterval(() => {
+                        thermal2dIndex = (thermal2dIndex + 1) % thermal2dFrames.length;
+                        document.getElementById('thermal2d_img').src = 'data:image/png;base64,' + thermal2dFrames[thermal2dIndex];
+                    }, 1000);
                 }
                 if (res.rf_plot) {
                     document.getElementById('rf_plot_img').src = 'data:image/png;base64,' + res.rf_plot;


### PR DESCRIPTION
## Summary
- shift the PCB stack so the radiator is on top and solar cells on the bottom
- include radiator view factor on the top boundary and use a Crank–Nicolson solver
- default to a 10 s timestep and 180 min runtime
- store 2‑D demo frames in Flask using the new timestep

## Testing
- `python -m py_compile radiation/2dthermal.py app.py`
- `python radiation/2dthermal.py | head -n 20`
- `python app.py >/tmp/app.log && tail -n 20 /tmp/app.log`


------
https://chatgpt.com/codex/tasks/task_e_6877d125b06c832884d0bbee3da64275