### PR TITLE
Re-charter orbital_btc_mining as Orbital Compute Lab

### DIFF
--- a/.agent-harness/README.md
+++ b/.agent-harness/README.md
@@ -1,0 +1,17 @@
+# Agent Harness
+
+This directory records the incubation task contract for Orbital Compute Lab.
+
+I0 intentionally does not include `.agent-harness/project.json`. The gap is
+tracked because the harness does not yet have a reviewed project schema for
+incubation repositories in this repo.
+
+Allowed I0 commands:
+
+- `.\eng.ps1 bootstrap`
+- `.\eng.ps1 verify`
+- `node scripts/validate-incubation-charter.mjs`
+- `node --test tests/incubation-charter.test.mjs`
+- `git diff --check`
+
+Legacy commands remain `not_run`.

--- a/.agent-harness/tasks/i0-audit-recharter.task.json
+++ b/.agent-harness/tasks/i0-audit-recharter.task.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": "0.1",
+  "task_id": "orbital-compute-lab-i0-audit-recharter",
+  "repository": "dyson-labs-org/orbital_btc_mining",
+  "local_directory_name": "orbital_btc_mining",
+  "classification": "incubation",
+  "release_gate": "I0 Audit/Re-charter",
+  "baseline_sha": "c93c7366edcd86b83896c3c39b753805183c3126",
+  "preserved_branch": "legacy/pre-orbital-compute-lab",
+  "work_branch": "incubation/orbital-compute-lab-charter",
+  "product_implementation": "not_started",
+  "external_calls": "none",
+  "legacy_source": "not_run",
+  "project_json": {
+    "status": "not_created",
+    "reason": "No reviewed incubation project schema is available for this repository yet."
+  },
+  "required_documents": [
+    "README.md",
+    "docs/product-charter.md",
+    "docs/safety-boundaries.md",
+    "docs/legacy-inventory.md",
+    "docs/audit-report.md",
+    "docs/research-assumptions.md",
+    "docs/verification-plan.md",
+    "docs/roadmap.md",
+    "docs/architecture/ADR-0001-recharter-as-orbital-compute-lab.md",
+    "docs/architecture/ADR-0002-deterministic-offline-first.md"
+  ],
+  "allowed_verify_commands": [
+    "git diff --check",
+    "node scripts/validate-incubation-charter.mjs",
+    "node --test tests/incubation-charter.test.mjs"
+  ],
+  "legacy_command_status": {
+    "pip install -r requirements.txt": "not_run",
+    "python app.py": "not_run",
+    "gunicorn app:app": "not_run",
+    "render build/start": "not_run",
+    "analysis/lastrow.py": "not_run",
+    "analysis/goog.py": "not_run",
+    "autocommit.py": "not_run",
+    "codex_merge.py": "not_run",
+    "package_json_scripts": "empty",
+    "pnpm_workspace_scripts": "empty",
+    "npx_commands": "empty",
+    "portal_health_invoice_integration_smoke_dispatch_exec": "empty"
+  },
+  "status_vocabulary": [
+    "passed",
+    "failed",
+    "skipped",
+    "not_run",
+    "empty",
+    "noop"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ bfg-*.jar
 
 # Misc
 .DS_Store
+
+# Harness artifacts
+.agent-harness/artifacts/
+.agent-harness/tmp/
+audit-output/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+This repository is an incubation lab named Orbital Compute Lab. Repository files,
+committed docs, validators, tests, ADRs, and evidence fixtures are authoritative;
+provider memory is recall only.
+
+Security boundaries:
+
+- Do not add provider-specific configuration, local absolute paths, secrets,
+  tokens, or live service credentials.
+- Do not silently mutate provider state.
+- Do not run legacy deployment, server, Google Sheets, email, package-install,
+  auto-commit, invoice, portal, smoke, integration, dispatch, or executor
+  commands during I0.
+- Do not add direct database integrations.
+- Do not create `.agent-harness/project.json` until the harness has a reviewed
+  project schema for incubation repositories.
+
+Definition of done:
+
+- Run `.\eng.ps1 verify` before completion.
+- Record structured evidence for executed checks under ignored artifact
+  directories when evidence is requested.
+- Distinguish `passed`, `failed`, `skipped`, `not_run`, `empty`, and `noop`.
+- Report untested claims honestly.
+- For roadmap status changes, use reviewed repository evidence and identify the
+  release gate advanced by the work.
+
+Dependencies:
+
+- Prefer built-in language/runtime capabilities.
+- Do not add runtime dependencies for I0.
+- Do not run package installation commands as part of I0 verification.
+
+Generated artifacts:
+
+- Write generated output under ignored artifact directories.
+- Do not commit transient evidence unless a task explicitly asks for committed
+  fixtures.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,62 @@
+# Orbital Compute Lab
+
+Orbital Compute Lab is an incubation repository for offline, deterministic study
+of orbital compute concepts. The current milestone re-charters the repository
+away from an operational "orbital BTC mining" web app and into a safety-first
+research lab.
+
+This repository is not production software, not an active mining service, and
+not authorized to call external services during harness verification. Legacy
+source files remain in the tree for auditability only until future milestones
+replace them with deterministic simulation components.
+
+## Current Status
+
+- Incubation stage: I0 Audit/Re-charter.
+- Product implementation: not_started.
+- Legacy application commands: not_run for this milestone.
+- External service calls during verification: none.
+- Baseline preserved at `legacy/pre-orbital-compute-lab`.
+- Baseline SHA: `c93c7366edcd86b83896c3c39b753805183c3126`.
+
+## Safety Boundary
+
+Allowed work in this repository is limited to documentation, deterministic
+offline validators, and future simulation code that can run without credentials,
+network calls, package installation, deployed services, or provider state
+changes.
+
+Do not run the legacy Flask app, Render deployment commands, Google Sheets or
+email helper scripts, package installs, or auto-commit helpers as part of this
+incubation milestone. See [docs/safety-boundaries.md](docs/safety-boundaries.md).
+
+## Verification
+
+The harness entry point is intentionally small:
+
+```powershell
+.\eng.ps1 bootstrap
+.\eng.ps1 verify
+```
+
+`bootstrap` performs no network calls, creates no artifacts, installs no
+packages, and runs no legacy commands. `verify` is limited to:
+
+- `git diff --check`
+- `node scripts/validate-incubation-charter.mjs`
+- `node --test tests/incubation-charter.test.mjs`
+
+## Key Documents
+
+- [Product charter](docs/product-charter.md)
+- [Safety boundaries](docs/safety-boundaries.md)
+- [Legacy inventory](docs/legacy-inventory.md)
+- [Audit report](docs/audit-report.md)
+- [Research assumptions](docs/research-assumptions.md)
+- [Verification plan](docs/verification-plan.md)
+- [Roadmap](docs/roadmap.md)
+- [ADR-0001: Re-charter as Orbital Compute Lab](docs/architecture/ADR-0001-recharter-as-orbital-compute-lab.md)
+- [ADR-0002: Deterministic offline-first](docs/architecture/ADR-0002-deterministic-offline-first.md)
+
+The previous `readme.txt` is retained as legacy evidence and is superseded by
+this README for current repository intent.

--- a/docs/architecture/ADR-0001-recharter-as-orbital-compute-lab.md
+++ b/docs/architecture/ADR-0001-recharter-as-orbital-compute-lab.md
@@ -1,0 +1,26 @@
+# ADR-0001: Re-charter As Orbital Compute Lab
+
+## Status
+
+Accepted for I0 incubation.
+
+## Context
+
+The repository baseline is an orbital Bitcoin-mining Flask application with
+deployment, Google Sheets, email, and local-path legacy surfaces. The requested
+milestone requires a safer provider-neutral incubation posture that preserves
+history while preventing accidental operational claims.
+
+## Decision
+
+Re-charter the repository as Orbital Compute Lab, an offline deterministic
+research incubation repository. The legacy app remains as audit evidence and is
+not an authorized execution path for I0.
+
+## Consequences
+
+- README and docs describe incubation rather than deployment.
+- Legacy commands are inventoried as `not_run`.
+- Harness verification validates the charter and documentation contract.
+- Future implementation must be deterministic, offline, and evidence-backed.
+- The existing repository name and local directory remain unchanged.

--- a/docs/architecture/ADR-0002-deterministic-offline-first.md
+++ b/docs/architecture/ADR-0002-deterministic-offline-first.md
@@ -1,0 +1,26 @@
+# ADR-0002: Deterministic Offline-First
+
+## Status
+
+Accepted for I0 incubation.
+
+## Context
+
+The legacy repository includes package installation, web server, deployment,
+Google Sheets, and email paths. Those paths make verification dependent on
+network access, credentials, external state, or mutable provider behavior.
+
+## Decision
+
+All I0 verification must be deterministic and offline. The harness may run only
+`git diff --check`, the built-in Node.js charter validator, and built-in Node.js
+tests. Bootstrap must not install dependencies or create artifacts.
+
+## Consequences
+
+- No package manager is needed for I0.
+- Legacy code correctness is not claimed by I0.
+- Future milestones must introduce deterministic fixtures before expanding the
+  verification surface.
+- Any optional live or provider-backed work must be explicitly chartered in a
+  later reviewed milestone.

--- a/docs/audit-report.md
+++ b/docs/audit-report.md
@@ -1,0 +1,105 @@
+# Audit Report
+
+## Scope
+
+Repository: `dyson-labs-org/orbital_btc_mining`.
+
+Baseline SHA: `c93c7366edcd86b83896c3c39b753805183c3126`.
+
+Preserved branch: `legacy/pre-orbital-compute-lab`.
+
+Work branch: `incubation/orbital-compute-lab-charter`.
+
+Audit date: 2026-06-23.
+
+## Baseline Finding
+
+The observed repository is not a gf-sdk JavaScript or TypeScript monorepo. It is
+a Python Flask/Render orbital Bitcoin-mining trade-study application with
+analysis scripts. This mismatch is recorded as an audit finding. No legacy
+runtime command was executed to reconcile the mismatch.
+
+## Static Command Audit
+
+Status: passed for static inspection, not_run for legacy execution.
+
+No legacy app command, package install, server, Render command, Google helper,
+email helper, portal health check, invoice command, integration command, smoke
+command, dispatch command, executor command, or package-manager script was run.
+
+The detailed command surface is in [legacy-inventory.md](legacy-inventory.md).
+
+## Credential And Secret Scan
+
+Status: passed_with_findings.
+
+Current tree and reachable history were scanned with redacted patterns for
+private-key markers, AWS access keys, Google API keys, GitHub tokens, Slack
+tokens, Stripe live keys, and generic secret assignments. No likely active credential was found by that scan.
+
+Environment-variable references were found in:
+
+- `analysis/lastrow.py` for `SENDER_EMAIL`.
+- `analysis/lastrow.py` for `APP_PASSWORD`.
+- `app.py` for `PORT`.
+
+These are references only, not committed secret values.
+
+## Privacy And Provenance Findings
+
+Status: passed_with_findings.
+
+Git history records deleted `user_reports/*.pdf` paths containing email
+addresses. The files are not present in the current tree, but the history and
+filenames are a privacy/provenance concern for future cleanup planning.
+
+The current tree also contains local absolute Windows paths in legacy source.
+
+## License Finding
+
+Status: failed for clean license provenance, accepted as documented I0 gap.
+
+`LICENSE` contains MIT license text with unresolved merge conflict markers. I0
+does not alter the file because this milestone is an audit/re-charter step with
+no legacy cleanup. A future reviewed cleanup must resolve the license file before
+any operational or distribution claim.
+
+## gf-sdk Duplication Assessment
+
+Status: passed for static comparison.
+
+Referenced repository: `dyson-labs-org/gf-sdk`.
+
+Observed gf-sdk HEAD: `ccdff5326cfd8f4b4123faebbeac477bb3d1235f`.
+
+Read-only comparison results:
+
+- Orbital tracked files: 32.
+- gf-sdk tracked files: 55.
+- Common paths: `.gitignore`, `LICENSE`.
+- Exact matching common-path hashes: 0.
+- Common basenames: `.gitignore`, `LICENSE`.
+
+No evidence of copied gf-sdk source was found in this static comparison. This is
+not a full authorship proof; it is a scoped repository/file-shape and exact-hash
+assessment.
+
+## External Endpoint And Service Findings
+
+Status: passed_with_findings.
+
+Legacy files reference Render, Google OAuth/Sheets, email delivery, a local
+Flask URL, a GitHub URL, and static AWS-named ground-station data. These are
+documented as legacy references and are outside I0 execution.
+
+## Release-Gate Classification
+
+I0 advances only the audit/re-charter gate for an incubation repository. It does not advance an operational pilot gate, a deployment gate, a mining gate, or a customer-readiness gate.
+
+## Open Follow-Ups
+
+- Resolve or replace the conflicted `LICENSE` file.
+- Decide how to handle historical personal-data filenames.
+- Quarantine or replace legacy external-service scripts.
+- Replace legacy app assumptions with deterministic offline simulation fixtures.
+- Add model validation data before any technical performance claim.

--- a/docs/legacy-inventory.md
+++ b/docs/legacy-inventory.md
@@ -1,0 +1,65 @@
+# Legacy Inventory
+
+This inventory was produced from static inspection of the repository at baseline
+SHA `c93c7366edcd86b83896c3c39b753805183c3126`.
+
+## Repository Shape
+
+Tracked file count: 32.
+
+Primary legacy surfaces:
+
+- `app.py`: Flask web app with `/`, `/orbit_visuals/<idx>`,
+  `/api/estimate_cost`, `/api/simulate`, and `/health` routes.
+- `main.py`: command-line style trade-study script with local absolute path
+  references.
+- `requirements.txt`: Python runtime/development dependencies.
+- `render.yaml` and `Procfile`: Render/gunicorn deployment surfaces.
+- `analysis/lastrow.py`: Google Sheets, OAuth, PDF output, and email workflow.
+- `analysis/goog.py`: Google Sheets OAuth helper.
+- `autocommit.py` and `codex_merge.py`: Git-mutating helper scripts.
+- `readme.txt`: legacy user setup instructions.
+- `LICENSE`: MIT text with unresolved merge conflict markers.
+
+## Command Surface
+
+| Command or surface | Status | Reason |
+| --- | --- | --- |
+| `pip install -r requirements.txt` | not_run | Network package installation is outside I0. |
+| `python app.py` | not_run | Starts a Flask server and executes legacy app code. |
+| `gunicorn app:app` | not_run | Deployment/server command. |
+| Render `buildCommand` and `startCommand` | not_run | Deployment service path. |
+| `analysis/lastrow.py` | not_run | Uses Google OAuth, Sheets, file output, and email. |
+| `analysis/goog.py` | not_run | Uses Google OAuth and Sheets. |
+| `autocommit.py` | not_run | Mutates Git state. |
+| `codex_merge.py` | not_run | Writes files, commits with Git, and may run `python app.py`. |
+| `package.json` scripts | empty | No `package.json` exists in the baseline tree. |
+| `pnpm` workspace scripts | empty | No `pnpm-workspace.yaml` exists in the baseline tree. |
+| `npx` commands | empty | No npx command surface was found. |
+| Portal health, invoice, integration, smoke, dispatch, executor commands | empty | Not present in this repository baseline. |
+
+## External References
+
+- `render.yaml`: Render web service configuration.
+- `analysis/lastrow.py`: Google Sheets URL and email sender flow.
+- `analysis/goog.py`: Google Sheets OAuth scope and placeholder sheet URL.
+- `readme.txt`: local Flask URL `http://127.0.0.1:5000`.
+- `radiation/rf_model.py`: static AWS-named ground-station records.
+- `analysis/lastrow.py`: legacy GitHub URL text.
+
+## Local Absolute Paths
+
+The current tree contains local Windows paths in:
+
+- `main.py`
+- `analysis/lastrow.py`
+
+Those paths are provenance risks and must not be copied into future production
+configuration.
+
+## Legacy Source Status
+
+Legacy source remains present and unmodified by I0 except for new documentation,
+harness files, and ignored artifact directories. It is retained for auditability
+until a future reviewed milestone decides whether to replace, quarantine, or
+remove it.

--- a/docs/product-charter.md
+++ b/docs/product-charter.md
@@ -1,0 +1,49 @@
+# Product Charter
+
+## Name
+
+Orbital Compute Lab.
+
+## Classification
+
+Incubation repository. This is not an operational pilot, not a deployed service,
+and not a provider integration.
+
+## Purpose
+
+Build a deterministic offline research environment for evaluating orbital
+compute tradeoffs before any production, deployment, mining, payment, or live
+provider integration is considered.
+
+## Near-Term Outcomes
+
+- Preserve the legacy repository state for review.
+- Document safety boundaries, provenance risks, command surfaces, and research
+  assumptions.
+- Establish a harness-compatible task contract and validator.
+- Define a roadmap from audit-only incubation to an optional demonstrator.
+
+## Non-Goals
+
+- No active Bitcoin mining.
+- No wallet, payment, invoice, or treasury integration.
+- No external service calls during verification.
+- No Render, Flask, Google Sheets, email, or provider deployment work.
+- No package installation or dependency update in I0.
+- No deletion of legacy source as part of this re-charter.
+
+## Product Principles
+
+- Offline first: all verification must run without network access.
+- Deterministic first: repeated runs should produce the same results.
+- Explainable first: assumptions, formulas, and confidence limits must be
+  inspectable.
+- Provider-neutral: do not add provider-specific configuration or credentials.
+- Audit-preserving: legacy material stays visible until a later reviewed
+  cleanup milestone explicitly retires it.
+
+## I0 Exit Criteria
+
+I0 is complete only when the charter, safety boundary, audit report, roadmap,
+task contract, validator, and local harness checks pass. I0 does not prove that
+the legacy simulation is correct, safe to deploy, or ready for users.

--- a/docs/research-assumptions.md
+++ b/docs/research-assumptions.md
@@ -1,0 +1,30 @@
+# Research Assumptions
+
+This document separates research assumptions from verified behavior.
+
+## Current Assumptions
+
+- Orbital compute can be studied initially as an offline simulation problem.
+- Energy availability, thermal behavior, communications windows, workload
+  scheduling, and economics should be modeled separately before being combined.
+- Any Bitcoin-related economics in the legacy code are illustrative only.
+- Static ground-station names in the legacy RF model are reference data, not a
+  live provider integration.
+- A future local AI advisor, if evaluated, must be optional and must not be a
+  source of truth for simulation results.
+
+## Not Yet Verified
+
+- Numerical correctness of legacy orbit, RF, thermal, power, and cost models.
+- Fitness of dependency versions in `requirements.txt`.
+- Suitability of any deployment configuration.
+- Accuracy of Bitcoin price, block reward, network hashrate, or revenue
+  assumptions.
+- Legal, privacy, licensing, or export-control readiness.
+- Operational feasibility of orbital compute or mining.
+
+## Evidence Standard
+
+Future milestones must attach deterministic fixtures, expected outputs,
+uncertainty bounds, and reviewed assumptions before claiming model correctness.
+External services and live credentials are not acceptable evidence for I0.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,65 @@
+# Roadmap
+
+Orbital Compute Lab advances through incubation gates. Passing one gate does not
+imply operational readiness.
+
+## I0 - Audit/Re-charter
+
+Status: in_progress for this milestone.
+
+Outcome: preserve the legacy baseline, document risks, define the product
+charter, add safety boundaries, establish harness verification, and keep legacy
+runtime commands `not_run`.
+
+Exit gate: local charter validator and harness checks pass.
+
+## I1 - Deterministic Simulation Kernel
+
+Outcome: introduce a minimal offline simulation kernel with deterministic input
+fixtures, expected outputs, and uncertainty notes.
+
+Exit gate: repeatable tests verify kernel behavior without external calls.
+
+## I2 - Workload/Scheduler
+
+Outcome: model workload windows, power limits, thermal limits, and scheduling
+decisions without provider integrations.
+
+Exit gate: scheduler fixtures cover nominal, constrained, and infeasible cases.
+
+## I3 - Explainability/Telemetry
+
+Outcome: produce explainable traces for assumptions, intermediate values,
+warnings, and confidence limits.
+
+Exit gate: every user-visible result can be traced to fixture inputs and model
+steps.
+
+## I4 - Optional Local AI Advisor Evaluation
+
+Outcome: evaluate whether a local-only advisor can summarize assumptions and
+risks without changing source-of-truth calculations.
+
+Exit gate: advisor is optional, offline, reproducible, and never required for
+verification.
+
+## I5 - Incubation Demonstrator
+
+Outcome: assemble the kernel, scheduler, and telemetry into an offline demo that
+shows the concept without deployment, mining, payments, or live services.
+
+Exit gate: demo evidence shows deterministic local operation and clear
+non-operational labeling.
+
+## 1.0 Decision Gate
+
+Outcome: decide whether to continue, archive, or re-scope the lab.
+
+Required before 1.0:
+
+- Clean license provenance.
+- Privacy history review.
+- Reviewed model assumptions and fixtures.
+- Active maintenance owner.
+- Security review of any retained legacy code.
+- Decision on whether any operational pilot is appropriate.

--- a/docs/safety-boundaries.md
+++ b/docs/safety-boundaries.md
@@ -1,0 +1,49 @@
+# Safety Boundaries
+
+## Operating Mode
+
+Orbital Compute Lab operates in incubation mode. Verification must be local,
+deterministic, and offline. The repository may contain legacy files that mention
+deployment, email, Google Sheets, web servers, or Bitcoin economics, but those
+paths are not authorized execution surfaces for I0.
+
+## Allowed In I0
+
+- Read-only static audit of repository files and Git history.
+- Documentation updates that re-charter the repository.
+- Harness metadata under `.agent-harness/`.
+- Built-in Node.js validation and test scripts.
+- `.\eng.ps1 bootstrap`.
+- `.\eng.ps1 verify`.
+- `git diff --check`.
+
+## Not Authorized In I0
+
+- `pip install -r requirements.txt`.
+- `python app.py`.
+- `gunicorn app:app`.
+- Render build or start commands.
+- Flask server execution.
+- Google OAuth, Google Sheets, or email scripts.
+- `analysis/lastrow.py` or `analysis/goog.py`.
+- `autocommit.py` or `codex_merge.py`.
+- `pnpm`, `npm install`, `npx`, package-manager builds, package-manager tests,
+  or package-manager lint commands.
+- Portal health checks, invoice creation, integration tests, smoke tests,
+  dispatch commands, executor commands, or live service probes.
+
+## Data And Credential Boundary
+
+- Do not commit secrets, tokens, local absolute paths, or live service
+  credentials.
+- Keep `.env`, `client.json`, and `analysis/client.json` ignored.
+- Treat historical `user_reports/*.pdf` filenames as personal-data provenance
+  evidence. The files are not present in the current tree, but their historical
+  presence remains a privacy review item.
+
+## External Service Boundary
+
+The current tree references Google Sheets, Gmail-style email delivery, Render,
+GitHub URLs, AWS Ground Station names in static data, and a local Flask URL.
+These references are legacy inventory only. Harness verification must not call
+those services.

--- a/docs/verification-plan.md
+++ b/docs/verification-plan.md
@@ -1,0 +1,50 @@
+# Verification Plan
+
+## I0 Verification Contract
+
+`.\eng.ps1 bootstrap` must:
+
+- create no artifacts;
+- perform no package installation;
+- call no network service;
+- run no legacy application command;
+- report legacy source as `not_run`;
+- report external calls as `none`;
+- report product implementation as `not_started`.
+
+`.\eng.ps1 verify` must run only:
+
+- `git diff --check`;
+- `node scripts/validate-incubation-charter.mjs`;
+- `node --test tests/incubation-charter.test.mjs`.
+
+## Status Vocabulary
+
+- `passed`: check executed and met its condition.
+- `failed`: check executed and did not meet its condition.
+- `skipped`: intentionally skipped with a stated reason.
+- `not_run`: execution was not attempted.
+- `empty`: the expected surface does not exist.
+- `noop`: command ran but had no state-changing work to do.
+
+## Required Local Evidence
+
+- Harness bootstrap summary.
+- Harness verify summary.
+- Validator output.
+- Node test output.
+- `git diff --check` result.
+- Redacted static secret scan summary.
+- Static command audit summary.
+
+Generated evidence belongs under ignored artifact directories such as
+`.agent-harness/artifacts/` or `audit-output/`.
+
+## Out-Of-Scope Checks For I0
+
+- Legacy Flask app execution.
+- Python dependency installation.
+- Render deployment.
+- Google Sheets or email workflows.
+- Portal health, invoice, smoke, integration, dispatch, or executor checks.
+- Performance, economics, or scientific correctness claims.

--- a/eng.ps1
+++ b/eng.ps1
@@ -1,0 +1,126 @@
+[CmdletBinding()]
+param(
+    [ValidateSet("bootstrap", "verify", "help")]
+    [string] $Command = "help"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function New-Summary {
+    param(
+        [string] $CommandName,
+        [array] $Checks
+    )
+
+    [ordered]@{
+        command = $CommandName
+        charter_status = "incubation"
+        legacy_source = "not_run"
+        external_calls = "none"
+        product_implementation = "not_started"
+        checks = $Checks
+    }
+}
+
+function Write-Summary {
+    param([hashtable] $Summary)
+    $Summary | ConvertTo-Json -Depth 6
+}
+
+function Invoke-Check {
+    param(
+        [string] $Name,
+        [scriptblock] $Action
+    )
+
+    $output = @(& $Action 2>&1 | ForEach-Object { "$_" })
+    $code = if ($null -eq $LASTEXITCODE) { 0 } else { $LASTEXITCODE }
+    if ($code -ne 0) {
+        return [ordered]@{
+            name = $Name
+            status = "failed"
+            exit_code = $code
+            output = $output
+        }
+    }
+
+    [ordered]@{
+        name = $Name
+        status = "passed"
+        exit_code = 0
+        output = $output
+    }
+}
+
+switch ($Command) {
+    "bootstrap" {
+        $checks = @(
+            [ordered]@{
+                name = "bootstrap"
+                status = "noop"
+                exit_code = 0
+                notes = "No artifacts, package installs, network calls, or legacy commands are run."
+            },
+            [ordered]@{
+                name = "legacy_source"
+                status = "not_run"
+                exit_code = 0
+            },
+            [ordered]@{
+                name = "external_calls"
+                status = "empty"
+                exit_code = 0
+            }
+        )
+        Write-Summary (New-Summary -CommandName "bootstrap" -Checks $checks)
+        exit 0
+    }
+    "verify" {
+        $checks = @()
+
+        $checks += Invoke-Check -Name "git diff --check" -Action {
+            & git diff --check
+        }
+        if ($checks[-1].status -eq "failed") {
+            Write-Summary (New-Summary -CommandName "verify" -Checks $checks)
+            exit $checks[-1].exit_code
+        }
+
+        $checks += Invoke-Check -Name "node scripts/validate-incubation-charter.mjs" -Action {
+            & node scripts/validate-incubation-charter.mjs
+        }
+        if ($checks[-1].status -eq "failed") {
+            Write-Summary (New-Summary -CommandName "verify" -Checks $checks)
+            exit $checks[-1].exit_code
+        }
+
+        $checks += Invoke-Check -Name "node --test tests/incubation-charter.test.mjs" -Action {
+            & node --test tests/incubation-charter.test.mjs
+        }
+        if ($checks[-1].status -eq "failed") {
+            Write-Summary (New-Summary -CommandName "verify" -Checks $checks)
+            exit $checks[-1].exit_code
+        }
+
+        $checks += [ordered]@{
+            name = "legacy_source"
+            status = "not_run"
+            exit_code = 0
+        }
+        $checks += [ordered]@{
+            name = "external_calls"
+            status = "empty"
+            exit_code = 0
+        }
+
+        Write-Summary (New-Summary -CommandName "verify" -Checks $checks)
+        exit 0
+    }
+    "help" {
+        "Usage: .\eng.ps1 bootstrap | verify | help"
+        "bootstrap: report incubation readiness without creating artifacts, installing packages, calling networks, or running legacy commands."
+        "verify: run git diff --check, the charter validator, and built-in Node.js tests."
+        exit 0
+    }
+}

--- a/scripts/validate-incubation-charter.mjs
+++ b/scripts/validate-incubation-charter.mjs
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { execFileSync } from "node:child_process";
+
+const root = process.cwd();
+
+const requiredFiles = [
+  "README.md",
+  "AGENTS.md",
+  "eng.ps1",
+  ".agent-harness/README.md",
+  ".agent-harness/tasks/i0-audit-recharter.task.json",
+  "docs/product-charter.md",
+  "docs/safety-boundaries.md",
+  "docs/legacy-inventory.md",
+  "docs/audit-report.md",
+  "docs/research-assumptions.md",
+  "docs/verification-plan.md",
+  "docs/roadmap.md",
+  "docs/architecture/ADR-0001-recharter-as-orbital-compute-lab.md",
+  "docs/architecture/ADR-0002-deterministic-offline-first.md",
+  "scripts/validate-incubation-charter.mjs",
+  "tests/incubation-charter.test.mjs"
+];
+
+const requiredText = {
+  "README.md": [
+    "Orbital Compute Lab",
+    "incubation",
+    "legacy/pre-orbital-compute-lab",
+    "c93c7366edcd86b83896c3c39b753805183c3126",
+    "Product implementation: not_started",
+    "Legacy application commands: not_run",
+    "External service calls during verification: none"
+  ],
+  "docs/product-charter.md": [
+    "Incubation repository",
+    "not an operational pilot",
+    "No active Bitcoin mining",
+    "I0 Exit Criteria"
+  ],
+  "docs/safety-boundaries.md": [
+    "Not Authorized In I0",
+    "pip install -r requirements.txt",
+    "python app.py",
+    "gunicorn app:app",
+    "autocommit.py",
+    "codex_merge.py"
+  ],
+  "docs/legacy-inventory.md": [
+    "`package.json` scripts | empty",
+    "`pnpm` workspace scripts | empty",
+    "Portal health, invoice, integration, smoke, dispatch, executor commands | empty",
+    "Local Absolute Paths"
+  ],
+  "docs/audit-report.md": [
+    "not a gf-sdk JavaScript or TypeScript monorepo",
+    "No likely active credential",
+    "unresolved merge conflict markers",
+    "ccdff5326cfd8f4b4123faebbeac477bb3d1235f",
+    "does not advance an operational pilot gate"
+  ],
+  "docs/verification-plan.md": [
+    "git diff --check",
+    "node scripts/validate-incubation-charter.mjs",
+    "node --test tests/incubation-charter.test.mjs",
+    "not_run",
+    "empty",
+    "noop"
+  ],
+  "docs/roadmap.md": [
+    "I0 - Audit/Re-charter",
+    "I1 - Deterministic Simulation Kernel",
+    "I2 - Workload/Scheduler",
+    "I3 - Explainability/Telemetry",
+    "I4 - Optional Local AI Advisor Evaluation",
+    "I5 - Incubation Demonstrator",
+    "1.0 Decision Gate"
+  ]
+};
+
+const forbiddenEngText = [
+  "pip install",
+  "npm install",
+  "pnpm",
+  "npx",
+  "gunicorn",
+  "flask run",
+  "python app.py",
+  "python main.py",
+  "Invoke-WebRequest",
+  "Invoke-RestMethod",
+  "curl ",
+  "wget",
+  "git push",
+  "git fetch",
+  "git pull",
+  "git clone",
+  "git add",
+  "git commit",
+  "Remove-Item",
+  "Set-Content",
+  "New-Item",
+  "Out-File",
+  "Tee-Object",
+  "Start-Process"
+];
+
+const allowedEngInvocations = new Set([
+  "& git diff --check",
+  "& node scripts/validate-incubation-charter.mjs",
+  "& node --test tests/incubation-charter.test.mjs"
+]);
+
+const baselineSha = "c93c7366edcd86b83896c3c39b753805183c3126";
+const preservedBranch = "legacy/pre-orbital-compute-lab";
+const workBranch = "incubation/orbital-compute-lab-charter";
+
+function read(relPath) {
+  return fs.readFileSync(path.join(root, relPath), "utf8");
+}
+
+function exists(relPath) {
+  return fs.existsSync(path.join(root, relPath));
+}
+
+function gitRevParse(ref) {
+  try {
+    return execFileSync("git", ["rev-parse", "--verify", ref], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+const failures = [];
+
+for (const relPath of requiredFiles) {
+  if (!exists(relPath)) {
+    failures.push(`missing required file: ${relPath}`);
+  }
+}
+
+if (exists(".agent-harness/project.json")) {
+  failures.push("unexpected .agent-harness/project.json");
+}
+
+for (const [relPath, snippets] of Object.entries(requiredText)) {
+  if (!exists(relPath)) {
+    continue;
+  }
+  const text = read(relPath);
+  for (const snippet of snippets) {
+    if (!text.includes(snippet)) {
+      failures.push(`${relPath} missing required text: ${snippet}`);
+    }
+  }
+}
+
+if (exists("eng.ps1")) {
+  const eng = read("eng.ps1");
+  for (const snippet of forbiddenEngText) {
+    if (eng.includes(snippet)) {
+      failures.push(`eng.ps1 contains forbidden execution surface: ${snippet}`);
+    }
+  }
+  const invocationLines = eng
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("& "));
+  for (const line of invocationLines) {
+    if (!allowedEngInvocations.has(line)) {
+      failures.push(`eng.ps1 contains unapproved external invocation: ${line}`);
+    }
+  }
+}
+
+if (exists(".gitignore")) {
+  const gitignore = read(".gitignore");
+  for (const ignored of [".agent-harness/artifacts/", ".agent-harness/tmp/", "audit-output/"]) {
+    if (!gitignore.includes(ignored)) {
+      failures.push(`.gitignore missing ignored artifact path: ${ignored}`);
+    }
+  }
+}
+
+if (exists(".agent-harness/tasks/i0-audit-recharter.task.json")) {
+  try {
+    const task = JSON.parse(read(".agent-harness/tasks/i0-audit-recharter.task.json"));
+    if (task.baseline_sha !== baselineSha) {
+      failures.push("task baseline_sha does not match preserved baseline");
+    }
+    if (task.preserved_branch !== preservedBranch) {
+      failures.push("task preserved_branch does not match required branch");
+    }
+    if (task.work_branch !== workBranch) {
+      failures.push("task work_branch does not match required branch");
+    }
+    if (task.classification !== "incubation") {
+      failures.push("task classification must be incubation");
+    }
+    if (task.product_implementation !== "not_started") {
+      failures.push("task product implementation must be not_started");
+    }
+    if (task.external_calls !== "none") {
+      failures.push("task external calls must be none");
+    }
+    if (task.legacy_source !== "not_run") {
+      failures.push("task legacy source must be not_run");
+    }
+    if (task.project_json?.status !== "not_created") {
+      failures.push("task must record .agent-harness/project.json as not_created");
+    }
+    for (const status of ["passed", "failed", "skipped", "not_run", "empty", "noop"]) {
+      if (!task.status_vocabulary?.includes(status)) {
+        failures.push(`task status vocabulary missing: ${status}`);
+      }
+    }
+  } catch (error) {
+    failures.push(`task JSON parse failed: ${error.message}`);
+  }
+}
+
+const preservedHead =
+  gitRevParse(`refs/heads/${preservedBranch}`) ??
+  gitRevParse(`refs/remotes/origin/${preservedBranch}`);
+if (preservedHead !== baselineSha) {
+  failures.push(`preserved branch ${preservedBranch} must resolve to ${baselineSha}`);
+}
+
+const summary = {
+  validator: "incubation-charter",
+  status: failures.length === 0 ? "passed" : "failed",
+  charter_status: "incubation",
+  legacy_source: "not_run",
+  external_calls: "none",
+  product_implementation: "not_started",
+  failures
+};
+
+console.log(JSON.stringify(summary, null, 2));
+
+if (failures.length > 0) {
+  process.exit(1);
+}

--- a/tests/incubation-charter.test.mjs
+++ b/tests/incubation-charter.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import test from "node:test";
+
+const baselineSha = "c93c7366edcd86b83896c3c39b753805183c3126";
+
+test("charter validator passes", () => {
+  const output = execFileSync(process.execPath, ["scripts/validate-incubation-charter.mjs"], {
+    encoding: "utf8"
+  });
+  const summary = JSON.parse(output);
+  assert.equal(summary.status, "passed");
+  assert.equal(summary.charter_status, "incubation");
+  assert.equal(summary.legacy_source, "not_run");
+  assert.equal(summary.external_calls, "none");
+  assert.equal(summary.product_implementation, "not_started");
+});
+
+test("task contract records incubation status and project-json gap", () => {
+  const task = JSON.parse(fs.readFileSync(".agent-harness/tasks/i0-audit-recharter.task.json", "utf8"));
+  assert.equal(task.baseline_sha, baselineSha);
+  assert.equal(task.preserved_branch, "legacy/pre-orbital-compute-lab");
+  assert.equal(task.work_branch, "incubation/orbital-compute-lab-charter");
+  assert.equal(task.classification, "incubation");
+  assert.equal(task.release_gate, "I0 Audit/Re-charter");
+  assert.equal(task.project_json.status, "not_created");
+  assert.equal(fs.existsSync(".agent-harness/project.json"), false);
+});
+
+test("eng verify surface remains offline and bounded", () => {
+  const eng = fs.readFileSync("eng.ps1", "utf8");
+  const invocationLines = eng
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("& "));
+  assert.deepEqual(invocationLines, [
+    "& git diff --check",
+    "& node scripts/validate-incubation-charter.mjs",
+    "& node --test tests/incubation-charter.test.mjs"
+  ]);
+  assert.doesNotMatch(
+    eng,
+    /pip install|npm install|pnpm|npx|gunicorn|flask run|python (?:app|main)\.py|Invoke-WebRequest|Invoke-RestMethod|curl |wget|git push|git fetch|git pull|git clone|git add|git commit|Remove-Item|Set-Content|New-Item|Out-File|Tee-Object|Start-Process/
+  );
+});
+
+test("preserved legacy branch resolves to the documented baseline", () => {
+  const head = execFileSync("git", ["rev-parse", "--verify", "legacy/pre-orbital-compute-lab"], {
+    encoding: "utf8"
+  }).trim();
+  assert.equal(head, baselineSha);
+});
+
+test("roadmap contains all incubation gates", () => {
+  const roadmap = fs.readFileSync("docs/roadmap.md", "utf8");
+  for (const gate of [
+    "I0 - Audit/Re-charter",
+    "I1 - Deterministic Simulation Kernel",
+    "I2 - Workload/Scheduler",
+    "I3 - Explainability/Telemetry",
+    "I4 - Optional Local AI Advisor Evaluation",
+    "I5 - Incubation Demonstrator",
+    "1.0 Decision Gate"
+  ]) {
+    assert.ok(roadmap.includes(gate));
+  }
+});


### PR DESCRIPTION
## Summary

- Re-charters `orbital_btc_mining` as Orbital Compute Lab incubation.
- Preserves the legacy baseline at `legacy/pre-orbital-compute-lab` with baseline SHA `c93c7366edcd86b83896c3c39b753805183c3126`.
- Adds audit docs, product charter, safety boundaries, roadmap, ADRs, AGENTS instructions, bounded `eng.ps1`, `.agent-harness` task contract, built-in Node validator, and Node tests.

## Safety Boundary

- Legacy app, package install, Render, Flask/gunicorn, Google Sheets/email, auto-commit, portal, invoice, integration, smoke, dispatch, and executor commands were not run.
- No `.agent-harness/project.json` is added; the schema gap is documented.
- Verification is offline and bounded to `git diff --check`, `node scripts/validate-incubation-charter.mjs`, and `node --test tests/incubation-charter.test.mjs`.

## Evidence

- `./eng.ps1 bootstrap`: passed as `noop`; legacy source `not_run`; external calls `none`.
- `./eng.ps1 verify`: passed.
- `node scripts/validate-incubation-charter.mjs`: passed.
- `node --test tests/incubation-charter.test.mjs`: 5 tests passed.
- `git diff --check`: passed.
- Redacted audit scan: no likely active credential found; environment references documented.
- Read-only reviewer verdict: `pass_with_findings`; medium and low findings were fixed before PR push.

Draft because this is an incubation re-charter and should remain review-gated.